### PR TITLE
Handle failure responses during boot sequence

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,10 +46,34 @@ def run_boot_sequence(logger, bus, timeout=5):
             for msg in msgs:
                 sender = msg.get("from")
                 content = msg.get("content", "")
-                if content == f"TASK_COMPLETE: {action}":
+                if isinstance(content, str) and content == f"TASK_COMPLETE: {action}":
                     acked.add(sender)
                     logger.log("MissionLead", f"Acknowledged {action} by {sender}")
-                elif content.startswith("SYSTEM_FAILURE:"):
+                elif isinstance(content, str) and content.startswith("FAILURE:"):
+                    payload = content.split("FAILURE:", 1)[1].strip()
+                    failure_action = payload
+                    failure_reason = "unknown"
+                    if "|" in payload:
+                        parts = payload.split("|", 1)
+                        failure_action = parts[0].strip()
+                        failure_reason = parts[1].strip()
+                    if failure_action == action:
+                        agent_name = sender or "Unknown"
+                        logger.log(
+                            "MissionLead",
+                            f"Failure reported by {agent_name} for {action}: {failure_reason}",
+                        )
+                        if sender in acked:
+                            acked.remove(sender)
+                        if sender:
+                            logger.log("MissionLead", f"Retrying {action} with {agent_name}")
+                            bus.send("MissionLead", agent_name, action)
+                    else:
+                        logger.log(
+                            "MissionLead",
+                            f"Received failure for {failure_action} from {sender} during {action}",
+                        )
+                elif isinstance(content, str) and content.startswith("SYSTEM_FAILURE:"):
                     failure = content.split(":", 1)[1].strip()
                     if failure == sys:
                         logger.log("MissionLead", f"Boot failure detected: {failure}")

--- a/tests/test_boot_sequence.py
+++ b/tests/test_boot_sequence.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+
+for path in (PROJECT_ROOT, SRC_ROOT):
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.insert(0, str_path)
+
+from main import run_boot_sequence
+from utils.message_bus import MessageBus
+
+
+class DummyLogger:
+    def __init__(self):
+        self.entries = []
+
+    def log(self, agent, message):
+        self.entries.append((agent, message))
+
+
+class BootTestBus(MessageBus):
+    def __init__(self):
+        super().__init__()
+        self.failure_injected = False
+
+    def send(self, sender, recipient, content):
+        super().send(sender, recipient, content)
+        if sender == "MissionLead" and isinstance(content, str):
+            if content.startswith("boot_"):
+                if recipient == "SpacecraftTechnician":
+                    if not self.failure_injected:
+                        self.failure_injected = True
+                        super().send(
+                            "SpacecraftTechnician",
+                            "MissionLead",
+                            f"FAILURE: {content} | actuator jam",
+                        )
+                    else:
+                        super().send(
+                            "SpacecraftTechnician",
+                            "MissionLead",
+                            f"TASK_COMPLETE: {content}",
+                        )
+                elif recipient == "SystemMonitor":
+                    super().send(
+                        "SystemMonitor",
+                        "MissionLead",
+                        f"TASK_COMPLETE: {content}",
+                    )
+            elif content.startswith("fix_"):
+                super().send(recipient, "MissionLead", f"TASK_COMPLETE: {content}")
+
+
+def test_boot_sequence_retries_after_failure():
+    logger = DummyLogger()
+    bus = BootTestBus()
+
+    result = run_boot_sequence(logger, bus, timeout=1.5)
+
+    assert result is True
+
+    failure_logs = [msg for agent, msg in logger.entries if "Failure reported" in msg]
+    assert failure_logs, "Boot sequence should log failure details"
+
+    retry_logs = [msg for agent, msg in logger.entries if "Retrying boot_power" in msg]
+    assert retry_logs, "Boot sequence should retry the failed boot command"


### PR DESCRIPTION
## Summary
- parse FAILURE messages during the boot process and retry matching actions instead of stalling
- log failure details for operators and resend the boot command when appropriate
- add a regression test covering a failure response during the boot sequence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d0237fc883248602291b8b5631df