### PR TITLE
Replace curses dashboard with Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ AERUM is an onboard AI crew system designed to autonomously operate satellites t
 - Autonomous spacecraft operation (simulated & hardware-capable)
 - Natural language interface for mission control
 - Modular architecture for extension (robotic arms, payloads, etc.)
+
+## Web Dashboard
+
+After the boot sequence completes you will be prompted in the console to select a mission. Once the mission is selected the Flask-powered dashboard starts automatically on `http://localhost:5000` (or the port defined by the `DASHBOARD_PORT` environment variable). The dashboard provides:
+
+- **Timeline of events** with live updates streamed from all agent logs.
+- **Agent status panels** summarising the latest message and update time per agent.
+- **Manual refresh controls** that can be used while testing without SSE support.
+
+### Running the dashboard locally
+
+```bash
+pip install -r requirements.txt
+python -m src.main
+```
+
+Follow the console prompt to select a mission. Leave the process running to keep the dashboard live. Press `Ctrl+C` to shut the agents and web server down.

--- a/src/interface/dashboard.py
+++ b/src/interface/dashboard.py
@@ -1,1 +1,213 @@
-# Placeholder for mission dashboard
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from flask import Flask, Response, jsonify, request, stream_with_context
+
+from .event_store import event_store, EventStore
+
+
+def _load_static_page() -> str:
+    """Return the HTML for the dashboard."""
+
+    return (
+        Path(__file__).with_name("dashboard.html").read_text()
+        if Path(__file__).with_name("dashboard.html").exists()
+        else _DEFAULT_HTML
+    )
+
+
+def create_app(store: Optional[EventStore] = None) -> Flask:
+    store = store or event_store
+    app = Flask(__name__)
+
+    page_cache = {"html": _load_static_page()}
+
+    @app.route("/")
+    def index() -> str:
+        return page_cache["html"]
+
+    @app.route("/api/events")
+    def api_events() -> Response:
+        limit_param = request.args.get("limit")
+        offset_param = request.args.get("offset")
+        try:
+            limit = int(limit_param) if limit_param is not None else 200
+        except ValueError:
+            limit = 200
+        try:
+            offset = int(offset_param) if offset_param is not None else 0
+        except ValueError:
+            offset = 0
+        return jsonify({"events": store.get_events(limit=limit, offset=offset)})
+
+    @app.route("/api/agents")
+    def api_agents() -> Response:
+        return jsonify({"agents": store.get_statuses()})
+
+    @app.route("/api/stream")
+    def api_stream() -> Response:
+        def generate():
+            subscriber = store.subscribe()
+            try:
+                while True:
+                    payload = subscriber.get()
+                    yield f"data: {json.dumps(payload)}\n\n"
+            finally:
+                store.unsubscribe(subscriber)
+
+        return Response(
+            stream_with_context(generate()),
+            mimetype="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    return app
+
+
+def launch_dashboard(store: Optional[EventStore] = None) -> threading.Thread:
+    """Start the dashboard web server in a background thread."""
+
+    store = store or event_store
+    app = create_app(store)
+    port = int(os.getenv("DASHBOARD_PORT", "5000"))
+
+    def run_app():
+        app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
+
+    thread = threading.Thread(target=run_app, daemon=True)
+    thread.start()
+    # Allow Flask to bind before returning to reduce connection errors in tests
+    time.sleep(0.2)
+    return thread
+
+
+_DEFAULT_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>AERUM Mission Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; background: #0b1120; color: #e2e8f0; }
+        header { padding: 16px 24px; background: #1e293b; box-shadow: 0 2px 6px rgba(0,0,0,0.4); }
+        h1 { margin: 0; font-size: 1.6rem; }
+        main { display: flex; gap: 24px; padding: 24px; }
+        section { background: #111827; border-radius: 12px; padding: 16px; flex: 1; overflow: hidden; }
+        #timeline { max-height: 70vh; overflow-y: auto; }
+        .event { border-bottom: 1px solid rgba(148, 163, 184, 0.2); padding: 12px 0; }
+        .event:last-child { border-bottom: none; }
+        .event .meta { font-size: 0.85rem; color: #94a3b8; margin-bottom: 4px; }
+        .event .message { font-size: 1rem; }
+        #agent-panels { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
+        .agent-card { background: #0f172a; border-radius: 10px; padding: 12px 16px; border: 1px solid rgba(148, 163, 184, 0.15); }
+        .agent-card h3 { margin: 0 0 4px; font-size: 1.1rem; }
+        .agent-card .status { font-size: 0.95rem; }
+        .agent-card .timestamp { font-size: 0.8rem; color: #64748b; margin-top: 6px; }
+        .status-pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 0.75rem; margin-left: 8px; }
+        .status-active { background: rgba(34,197,94,0.2); color: #4ade80; }
+        .status-fault { background: rgba(248,113,113,0.2); color: #f87171; }
+        button { background: #2563eb; color: white; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        #controls { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+        #controls h2 { margin: 0; font-size: 1.2rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>📡 AERUM Mission Control Dashboard</h1>
+        <p>Timeline of events and live agent status updates.</p>
+    </header>
+    <main>
+        <section>
+            <div id="controls">
+                <h2>Event Timeline</h2>
+                <button id="refresh-btn">Refresh</button>
+            </div>
+            <div id="timeline"></div>
+        </section>
+        <section>
+            <h2>Agent Status</h2>
+            <div id="agent-panels"></div>
+        </section>
+    </main>
+    <script>
+        const timelineEl = document.getElementById('timeline');
+        const agentPanelsEl = document.getElementById('agent-panels');
+        const refreshBtn = document.getElementById('refresh-btn');
+
+        function renderEvent(event) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'event';
+            wrapper.innerHTML = `
+                <div class="meta">
+                    <strong>${event.agent}</strong> · ${new Date(event.timestamp).toLocaleTimeString()} · ${event.category}
+                </div>
+                <div class="message">${event.message}</div>
+            `;
+            return wrapper;
+        }
+
+        function renderAgent(agent) {
+            const card = document.createElement('div');
+            card.className = 'agent-card';
+            const isFault = agent.status.toLowerCase().includes('fail');
+            const pillClass = isFault ? 'status-fault' : 'status-active';
+            const pillText = isFault ? 'Attention' : 'Nominal';
+            card.innerHTML = `
+                <h3>${agent.agent}<span class="status-pill ${pillClass}">${pillText}</span></h3>
+                <div class="status">${agent.status}</div>
+                <div class="timestamp">Updated ${new Date(agent.timestamp).toLocaleTimeString()}</div>
+            `;
+            return card;
+        }
+
+        function refreshData() {
+            fetch('/api/events?limit=200')
+                .then(res => res.json())
+                .then(data => {
+                    timelineEl.innerHTML = '';
+                    data.events.forEach(event => {
+                        timelineEl.appendChild(renderEvent(event));
+                    });
+                });
+
+            fetch('/api/agents')
+                .then(res => res.json())
+                .then(data => {
+                    agentPanelsEl.innerHTML = '';
+                    data.agents.forEach(agent => {
+                        agentPanelsEl.appendChild(renderAgent(agent));
+                    });
+                });
+        }
+
+        function connectStream() {
+            const source = new EventSource('/api/stream');
+            source.onmessage = (event) => {
+                const payload = JSON.parse(event.data);
+                if (payload.type === 'event') {
+                    const entry = renderEvent(payload.event);
+                    timelineEl.insertBefore(entry, timelineEl.firstChild);
+                }
+                if (payload.type === 'status') {
+                    refreshData();
+                }
+            };
+            source.onerror = () => {
+                source.close();
+                setTimeout(connectStream, 2000);
+            };
+        }
+
+        refreshBtn.addEventListener('click', refreshData);
+        refreshData();
+        connectStream();
+    </script>
+</body>
+</html>
+"""
+

--- a/src/interface/event_store.py
+++ b/src/interface/event_store.py
@@ -1,0 +1,109 @@
+import json
+import threading
+from collections import deque
+from datetime import datetime
+from queue import Queue
+from typing import Deque, Dict, List, Optional
+
+
+class EventStore:
+    """Thread-safe in-memory store for timeline events and agent status."""
+
+    def __init__(self, max_events: int = 1000):
+        self._events: Deque[dict] = deque(maxlen=max_events)
+        self._statuses: Dict[str, dict] = {}
+        self._lock = threading.Lock()
+        self._subscribers: List[Queue] = []
+        self._counter = 0
+
+    def _next_id(self) -> int:
+        with self._lock:
+            self._counter += 1
+            return self._counter
+
+    def _broadcast(self, payload: dict) -> None:
+        """Send payload to all active subscribers."""
+        dead: List[Queue] = []
+        for q in list(self._subscribers):
+            try:
+                q.put_nowait(payload)
+            except Exception:
+                dead.append(q)
+        if dead:
+            with self._lock:
+                for q in dead:
+                    if q in self._subscribers:
+                        self._subscribers.remove(q)
+
+    def record_event(
+        self,
+        agent: str,
+        message: str,
+        *,
+        timestamp: Optional[datetime] = None,
+        category: str = "log",
+    ) -> dict:
+        """Add a timeline event and update the agent's latest status."""
+
+        ts = (timestamp or datetime.utcnow()).isoformat()
+        event = {
+            "id": self._next_id(),
+            "timestamp": ts,
+            "agent": agent,
+            "message": message,
+            "category": category,
+        }
+        with self._lock:
+            self._events.append(event)
+            self._statuses[agent] = {
+                "agent": agent,
+                "status": message,
+                "timestamp": ts,
+            }
+        self._broadcast({"type": "event", "event": event})
+        self._broadcast(
+            {
+                "type": "status",
+                "status": self._statuses[agent],
+            }
+        )
+        return event
+
+    def get_events(self, *, limit: Optional[int] = None, offset: int = 0) -> List[dict]:
+        """Return events ordered from latest to oldest."""
+
+        with self._lock:
+            events = list(self._events)
+        events.reverse()
+        if offset:
+            events = events[offset:]
+        if limit is not None:
+            events = events[:limit]
+        return events
+
+    def get_statuses(self) -> List[dict]:
+        with self._lock:
+            return list(self._statuses.values())
+
+    def subscribe(self) -> Queue:
+        q: Queue = Queue()
+        with self._lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: Queue) -> None:
+        with self._lock:
+            if q in self._subscribers:
+                self._subscribers.remove(q)
+
+    def to_json(self) -> str:
+        with self._lock:
+            payload = {
+                "events": list(self._events),
+                "statuses": list(self._statuses.values()),
+            }
+        return json.dumps(payload)
+
+
+event_store = EventStore()
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,6 @@
 import os
 import threading
 import time
-import curses
-from collections import deque
-from datetime import datetime
 from utils.logger import Logger
 from utils.message_bus import MessageBus
 from agents.mission_lead import MissionLead
@@ -11,20 +8,19 @@ from agents.orbital_engineer import OrbitalEngineer
 from agents.mission_specialist import MissionSpecialist
 from agents.spacecraft_technician import SpacecraftTechnician
 from agents.monitoring_agent import MonitoringAgent
+from interface.dashboard import launch_dashboard
+from interface.event_store import event_store
 
-# Buffer for UI logs
-log_buffer = deque(maxlen=200)
-agent_status = {}
 
-# Wrap logger to capture all agent messages in the UI log
 def wrap_logger_for_ui(logger):
-    orig_log = logger.log
+    """Proxy logger to capture log lines into the web dashboard event store."""
+
+    original_log = logger.log
+
     def ui_log(agent, message):
-        orig_log(agent, message)
-        timestamp = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-        entry = f"[{timestamp}] [{agent}] {message}"
-        log_buffer.append(entry)
-        agent_status[agent] = message
+        original_log(agent, message)
+        event_store.record_event(agent, message)
+
     logger.log = ui_log
 
 # Pre-mission boot sequence (unchanged)
@@ -46,10 +42,34 @@ def run_boot_sequence(logger, bus, timeout=5):
             for msg in msgs:
                 sender = msg.get("from")
                 content = msg.get("content", "")
-                if content == f"TASK_COMPLETE: {action}":
+                if isinstance(content, str) and content == f"TASK_COMPLETE: {action}":
                     acked.add(sender)
                     logger.log("MissionLead", f"Acknowledged {action} by {sender}")
-                elif content.startswith("SYSTEM_FAILURE:"):
+                elif isinstance(content, str) and content.startswith("FAILURE:"):
+                    payload = content.split("FAILURE:", 1)[1].strip()
+                    failure_action = payload
+                    failure_reason = "unknown"
+                    if "|" in payload:
+                        parts = payload.split("|", 1)
+                        failure_action = parts[0].strip()
+                        failure_reason = parts[1].strip()
+                    if failure_action == action:
+                        agent_name = sender or "Unknown"
+                        logger.log(
+                            "MissionLead",
+                            f"Failure reported by {agent_name} for {action}: {failure_reason}",
+                        )
+                        if sender in acked:
+                            acked.remove(sender)
+                        if sender:
+                            logger.log("MissionLead", f"Retrying {action} with {agent_name}")
+                            bus.send("MissionLead", agent_name, action)
+                    else:
+                        logger.log(
+                            "MissionLead",
+                            f"Received failure for {failure_action} from {sender} during {action}",
+                        )
+                elif isinstance(content, str) and content.startswith("SYSTEM_FAILURE:"):
                     failure = content.split(":", 1)[1].strip()
                     if failure == sys:
                         logger.log("MissionLead", f"Boot failure detected: {failure}")
@@ -64,85 +84,6 @@ def run_boot_sequence(logger, bus, timeout=5):
             return False
     logger.log("MissionLead", "All systems nominal.")
     return True
-
-# Dashboard UI: Agent Status, Task Status, Logs
-def dashboard_loop(stdscr, mission_file, mission_lead, bus):
-    curses.curs_set(0)
-    stdscr.nodelay(True)
-    threading.Thread(target=lambda: mission_lead.run(mission_file), daemon=True).start()
-
-    while True:
-        stdscr.erase()
-        height, width = stdscr.getmaxyx()
-
-        # Header
-        try:
-            stdscr.addstr(0, 2, f"📡 AERUM MISSION CONTROL - Mission: {mission_file}")
-            stdscr.addstr(1, 2, "Press 'q' to quit")
-        except curses.error:
-            pass
-
-        # Agent Status Panel
-        row = 3
-        try:
-            stdscr.addstr(row, 2, "Agent Status:")
-        except curses.error:
-            pass
-        row += 1
-        # truncate status to prevent wrapping
-        max_col = width // 2 - 4
-        for agent, status in agent_status.items():
-            if row >= height - 1:
-                break
-            try:
-                stdscr.addstr(row, 4, f"{agent}: {status}"[:max_col])
-            except curses.error:
-                pass
-            row += 1
-
-        # Task Status Panel (moved above logs)
-        steps = mission_lead.load_mission(mission_file).get('steps', [])
-        completed = {e.split("TASK_COMPLETE:",1)[1].strip() for e in log_buffer if "TASK_COMPLETE:" in e}
-        task_col = (width // 2) + 2
-        try:
-            stdscr.addstr(3, task_col, "Task Status:")
-        except curses.error:
-            pass
-        for idx, step in enumerate(steps, start=1):
-            if 3 + idx >= height - 1:
-                break
-            ch = "✔" if step['action'] in completed else "✖"
-            try:
-                stdscr.addstr(3 + idx, task_col, f"{ch} {step['action']}"[:width-task_col-2])
-            except curses.error:
-                pass
-
-        # Logs Panel (recent 15 entries)
-        max_logs = 15
-        recent_logs = list(log_buffer)[-max_logs:]
-        log_row_start = len(steps) + 10
-        col_mid = 2
-        try:
-            stdscr.addstr(log_row_start - 1, col_mid, "Logs:")
-        except curses.error:
-            pass
-        log_row = log_row_start
-        for entry in recent_logs:
-            if log_row >= height - 1:
-                break
-            try:
-                stdscr.addstr(log_row, col_mid, entry[:width-4])
-            except curses.error:
-                pass
-            log_row += 1
-
-        stdscr.refresh()
-        try:
-            if stdscr.getch() == ord('q'):
-                break
-        except curses.error:
-            pass
-        time.sleep(0.2)
 
 # Mission selection via console
 def select_mission():
@@ -180,4 +121,13 @@ if __name__ == "__main__":
     threading.Thread(target=specialist.run, daemon=True).start()
 
     lead = MissionLead(logger, bus)
-    curses.wrapper(dashboard_loop, mission, lead, bus)
+    threading.Thread(target=lead.run, args=(mission,), daemon=True).start()
+
+    launch_dashboard()
+
+    print("Dashboard running at http://localhost:{}".format(os.getenv("DASHBOARD_PORT", "5000")))
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nShutting down AERUM controllers...")

--- a/tests/test_boot_sequence.py
+++ b/tests/test_boot_sequence.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+
+for path in (PROJECT_ROOT, SRC_ROOT):
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.insert(0, str_path)
+
+from main import run_boot_sequence
+from utils.message_bus import MessageBus
+
+
+class DummyLogger:
+    def __init__(self):
+        self.entries = []
+
+    def log(self, agent, message):
+        self.entries.append((agent, message))
+
+
+class BootTestBus(MessageBus):
+    def __init__(self):
+        super().__init__()
+        self.failure_injected = False
+
+    def send(self, sender, recipient, content):
+        super().send(sender, recipient, content)
+        if sender == "MissionLead" and isinstance(content, str):
+            if content.startswith("boot_"):
+                if recipient == "SpacecraftTechnician":
+                    if not self.failure_injected:
+                        self.failure_injected = True
+                        super().send(
+                            "SpacecraftTechnician",
+                            "MissionLead",
+                            f"FAILURE: {content} | actuator jam",
+                        )
+                    else:
+                        super().send(
+                            "SpacecraftTechnician",
+                            "MissionLead",
+                            f"TASK_COMPLETE: {content}",
+                        )
+                elif recipient == "SystemMonitor":
+                    super().send(
+                        "SystemMonitor",
+                        "MissionLead",
+                        f"TASK_COMPLETE: {content}",
+                    )
+            elif content.startswith("fix_"):
+                super().send(recipient, "MissionLead", f"TASK_COMPLETE: {content}")
+
+
+def test_boot_sequence_retries_after_failure():
+    logger = DummyLogger()
+    bus = BootTestBus()
+
+    result = run_boot_sequence(logger, bus, timeout=1.5)
+
+    assert result is True
+
+    failure_logs = [msg for agent, msg in logger.entries if "Failure reported" in msg]
+    assert failure_logs, "Boot sequence should log failure details"
+
+    retry_logs = [msg for agent, msg in logger.entries if "Retrying boot_power" in msg]
+    assert retry_logs, "Boot sequence should retry the failed boot command"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,61 @@
+import threading
+import time
+
+import pytest
+
+from interface.dashboard import create_app
+from interface.event_store import EventStore
+
+
+@pytest.fixture
+def store():
+    return EventStore(max_events=10)
+
+
+@pytest.fixture
+def app(store):
+    return create_app(store)
+
+
+def test_event_store_records_events(store):
+    store.record_event("AgentA", "Event 1")
+    store.record_event("AgentB", "Event 2")
+
+    events = store.get_events(limit=5)
+    assert events[0]["message"] == "Event 2"
+    assert events[1]["agent"] == "AgentA"
+
+    statuses = {s["agent"]: s for s in store.get_statuses()}
+    assert statuses["AgentB"]["status"] == "Event 2"
+
+
+def test_api_endpoints_return_recent_events(app, store):
+    client = app.test_client()
+    store.record_event("Agent", "Ready")
+
+    events_resp = client.get("/api/events?limit=1")
+    data = events_resp.get_json()
+    assert data["events"][0]["message"] == "Ready"
+
+    agents_resp = client.get("/api/agents")
+    agent_payload = agents_resp.get_json()
+    assert agent_payload["agents"][0]["status"] == "Ready"
+
+
+def test_event_store_streams_updates(store):
+    subscriber = store.subscribe()
+
+    def push_event():
+        time.sleep(0.05)
+        store.record_event("Agent", "Streaming")
+
+    threading.Thread(target=push_event, daemon=True).start()
+
+    payload = subscriber.get(timeout=1.0)
+    assert payload["type"] == "event"
+    assert payload["event"]["message"] == "Streaming"
+
+    status_payload = subscriber.get(timeout=1.0)
+    assert status_payload["type"] == "status"
+
+    store.unsubscribe(subscriber)


### PR DESCRIPTION
## Summary
- replace the curses CLI dashboard with a Flask-powered web experience and live SSE updates
- capture agent logs in a thread-safe event store to back the new events, agents, and stream endpoints
- document the dashboard workflow and add tests covering the event store, APIs, and streaming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d0237fc883248602291b8b5631df