### PR TITLE
feat: add runtime controller and ui-first dashboard

### DIFF
--- a/src/agents/mission_lead.py
+++ b/src/agents/mission_lead.py
@@ -3,6 +3,7 @@ import os
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
+from interface.event_store import event_store
 from utils.planner import check_conditions
 
 
@@ -155,7 +156,11 @@ class MissionLead:
             self._abort_mode = True
         self._abort_requested = False if is_abort_mission else self._abort_requested
 
-        self.log(f"Starting mission: {mission.get('name', mission_filename)}")
+        mission_name = mission.get("name", mission_filename)
+        self.log(f"Starting mission: {mission_name}")
+        if not is_abort_mission:
+            event_store.set_agent_state(self.name, status=f"Executing {mission_name}")
+            event_store.update_mission_status("running", message=f"Executing {mission_name}")
 
         steps = mission.get("steps", [])
         tracked_actions = [
@@ -164,9 +169,12 @@ class MissionLead:
             if step.get("action") and step.get("recipients")
         ]
 
+        mission_failed = False
+
         for step in steps:
             if self._abort_requested and not is_abort_mission:
                 self.log("Abort requested. Halting current mission execution.")
+                mission_failed = True
                 break
 
             action = step.get("action")
@@ -180,6 +188,12 @@ class MissionLead:
             conditions = step.get("conditions")
             if conditions and not check_conditions(self.state, conditions):
                 self.log(f"Skipping {action}: mission conditions unmet -> {conditions}.")
+                if not is_abort_mission:
+                    event_store.update_mission_step(
+                        action,
+                        "skipped",
+                        detail="Conditions unmet",
+                    )
                 continue
 
             metadata = {
@@ -190,6 +204,10 @@ class MissionLead:
                 "retry_delay": step.get("retry_delay", 0.5),
             }
 
+            if not is_abort_mission:
+                detail = f"Dispatched to {', '.join(recipients)}" if recipients else "No recipients"
+                event_store.update_mission_step(action, "running", detail=detail)
+
             success, failure_reason = self._dispatch_step(action, recipients, metadata)
             task_state = self.state.setdefault("tasks", {}).setdefault(
                 action, {"agents": [], "status": None, "last_reason": None}
@@ -197,10 +215,23 @@ class MissionLead:
             if success:
                 task_state["status"] = "COMPLETE"
                 self.log(f"Step {action} completed successfully.")
+                if not is_abort_mission:
+                    event_store.update_mission_step(
+                        action,
+                        "complete",
+                        detail="Step completed successfully",
+                    )
             else:
                 task_state["status"] = "FAILED"
                 task_state["last_reason"] = failure_reason
                 self.log(f"Step {action} marked as FAILURE: {failure_reason}.")
+                if not is_abort_mission:
+                    event_store.update_mission_step(
+                        action,
+                        "failed",
+                        detail=failure_reason or "Unknown failure",
+                    )
+                mission_failed = True
 
             if self._abort_requested and not is_abort_mission:
                 break
@@ -220,9 +251,20 @@ class MissionLead:
         self.log(f"Completed {len(completed)}/{total} tracked steps.")
         if len(completed) >= total and total > 0:
             self.log("All tracked tasks successfully completed. Mission is complete.")
+            if not is_abort_mission:
+                event_store.update_mission_status("complete", message="Mission completed successfully")
         elif total > 0:
             self.log("Mission ended with incomplete or failed tasks.")
+            if not is_abort_mission:
+                event_store.update_mission_status("failed", message="Mission ended with failures")
+                mission_failed = True
+        elif not is_abort_mission:
+            status = "failed" if mission_failed else "complete"
+            message = "Mission ended" if mission_failed else "Mission finished"
+            event_store.update_mission_status(status, message=message)
 
         self._abort_mode = previous_abort_state
         if not is_abort_mission:
             self._abort_requested = False
+            final_status = "Mission failed" if mission_failed else "Mission complete"
+            event_store.set_agent_state(self.name, status=final_status)

--- a/src/agents/monitoring_agent.py
+++ b/src/agents/monitoring_agent.py
@@ -2,6 +2,7 @@ import time
 from typing import Any, Dict, Tuple
 
 from .base_agent import BaseAgent
+from interface.event_store import event_store
 
 
 class MonitoringAgent(BaseAgent):
@@ -12,6 +13,7 @@ class MonitoringAgent(BaseAgent):
             "systems": {
                 "power_ok": True,
                 "comms_ok": True,
+                "o2_ok": True,
             },
             "boot_pending": {
                 "power": True,
@@ -37,6 +39,7 @@ class MonitoringAgent(BaseAgent):
                 self.log("Verifying power system startup...")
                 self.state["boot_pending"]["power"] = False
                 self.send("MissionLead", "TASK_COMPLETE: boot_power")
+                event_store.set_system_state("power", "nominal", detail="Power verified by monitoring")
             else:
                 self.log("Power system failure detected during boot")
                 self.send("MissionLead", "SYSTEM_FAILURE: power")
@@ -46,6 +49,7 @@ class MonitoringAgent(BaseAgent):
                 self.log("Verifying communications system startup...")
                 self.state["boot_pending"]["comms"] = False
                 self.send("MissionLead", "TASK_COMPLETE: boot_comms")
+                event_store.set_system_state("comms", "nominal", detail="Comms verified by monitoring")
             else:
                 self.log("Communications failure detected during boot")
                 self.send("MissionLead", "SYSTEM_FAILURE: comms")
@@ -54,10 +58,12 @@ class MonitoringAgent(BaseAgent):
             self.log("Power system repaired, resetting status...")
             systems["power_ok"] = True
             self.send("MissionLead", "TASK_COMPLETE: fix_power")
+            event_store.set_system_state("power", "nominal", detail="Power system nominal")
         elif action == "fix_comms":
             self.log("Communications system repaired, resetting status...")
             systems["comms_ok"] = True
             self.send("MissionLead", "TASK_COMPLETE: fix_comms")
+            event_store.set_system_state("comms", "nominal", detail="Communications nominal")
         else:
             self.log(f"No monitoring handler defined for {action}")
             self.send("MissionLead", f"TASK_COMPLETE: {action}")
@@ -70,11 +76,18 @@ class MonitoringAgent(BaseAgent):
         if not systems["power_ok"]:
             self.log("Power system failure detected")
             self.send("MissionLead", "SYSTEM_FAILURE: power")
+            event_store.set_system_state("power", "fault", detail="Power system failure detected")
         if not systems["comms_ok"]:
             self.log("Communications failure detected")
             self.send("MissionLead", "SYSTEM_FAILURE: comms")
+            event_store.set_system_state("comms", "fault", detail="Comms failure detected")
+        if systems.get("o2_ok"):
+            event_store.set_system_state("o2", "nominal", detail="Life support stable")
+        else:
+            event_store.set_system_state("o2", "fault", detail="Life support anomaly")
 
     def run(self):
+        event_store.set_agent_state(self.name, status="Monitoring systems")
         while True:
             messages = self.bus.fetch(self.name)
             for msg in messages:

--- a/src/agents/spacecraft_technician.py
+++ b/src/agents/spacecraft_technician.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any, Dict, Tuple
 
 from .base_agent import BaseAgent
+from interface.event_store import event_store
 
 
 class SpacecraftTechnician(BaseAgent):
@@ -27,16 +28,24 @@ class SpacecraftTechnician(BaseAgent):
     def _perform_action(self, action: str) -> None:
         if action == "boot_power":
             self.log("Power systems powering on...")
+            event_store.set_system_state("power", "booting", detail="Power system engaging")
             self.send("MissionLead", "TASK_COMPLETE: boot_power")
+            event_store.set_system_state("power", "nominal", detail="Power system online")
         elif action == "boot_comms":
             self.log("Communications systems initializing...")
+            event_store.set_system_state("comms", "booting", detail="Initializing comms array")
             self.send("MissionLead", "TASK_COMPLETE: boot_comms")
+            event_store.set_system_state("comms", "nominal", detail="Communications online")
         elif action == "fix_power":
             self.log("Repairing power system...")
+            event_store.set_system_state("power", "maintenance", detail="Repairing power system")
             self.send("MissionLead", "TASK_COMPLETE: fix_power")
+            event_store.set_system_state("power", "nominal", detail="Power system restored")
         elif action == "fix_comms":
             self.log("Repairing communications system...")
+            event_store.set_system_state("comms", "maintenance", detail="Repairing communications")
             self.send("MissionLead", "TASK_COMPLETE: fix_comms")
+            event_store.set_system_state("comms", "nominal", detail="Communications restored")
         elif action.upper().startswith("REPAIR"):
             target = action.split(":", 1)[1].strip() if ":" in action else self.name
             self.log(f"Received repair command for {target}. Restoring health.")

--- a/src/interface/dashboard.html
+++ b/src/interface/dashboard.html
@@ -1,0 +1,627 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>AERUM Mission Control</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            font-family: "Inter", "Segoe UI", Arial, sans-serif;
+            background: radial-gradient(circle at top left, #1e3a8a, #0b1120 40%);
+            color: #e2e8f0;
+            min-height: 100vh;
+        }
+        header {
+            padding: 24px 32px;
+            background: rgba(15, 23, 42, 0.75);
+            backdrop-filter: blur(12px);
+            border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 1.8rem;
+            letter-spacing: 0.04em;
+        }
+        header p {
+            margin: 4px 0 0;
+            color: #94a3b8;
+        }
+        main.layout {
+            display: grid;
+            grid-template-columns: minmax(320px, 380px) 1fr;
+            gap: 20px;
+            padding: 24px 32px 48px;
+        }
+        .stack {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        section.panel {
+            background: rgba(15, 23, 42, 0.92);
+            border: 1px solid rgba(148, 163, 184, 0.16);
+            border-radius: 16px;
+            padding: 20px;
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+        }
+        section.panel h2 {
+            margin: 0 0 12px;
+            font-size: 1.1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #a5b4fc;
+        }
+        .panel-controls {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+        .panel-controls h2 {
+            margin: 0;
+        }
+        button.primary {
+            background: linear-gradient(135deg, #2563eb, #1d4ed8);
+            border: none;
+            color: #fff;
+            padding: 8px 16px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button.primary:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+            box-shadow: none;
+            transform: none;
+        }
+        button.primary:not(:disabled):hover {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 20px rgba(37, 99, 235, 0.45);
+        }
+        .status-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+        }
+        .status-idle { background: rgba(148, 163, 184, 0.18); color: #cbd5f5; }
+        .status-running { background: rgba(129, 140, 248, 0.25); color: #c7d2fe; }
+        .status-complete { background: rgba(34, 197, 94, 0.25); color: #bbf7d0; }
+        .status-failed { background: rgba(248, 113, 113, 0.25); color: #fecaca; }
+        .status-pending { background: rgba(59, 130, 246, 0.2); color: #c7d2fe; }
+        ul.boot-stages {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        ul.boot-stages li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px;
+            border-radius: 12px;
+            background: rgba(30, 41, 59, 0.8);
+            border: 1px solid rgba(148, 163, 184, 0.14);
+        }
+        ul.boot-stages li span.name {
+            font-weight: 600;
+            text-transform: capitalize;
+        }
+        .boot-message {
+            margin-top: 12px;
+            color: #94a3b8;
+            font-size: 0.85rem;
+        }
+        select {
+            width: 100%;
+            background: rgba(15, 23, 42, 0.85);
+            color: #e2e8f0;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            border-radius: 10px;
+            padding: 10px 12px;
+            font-size: 0.95rem;
+        }
+        .mission-summary {
+            background: rgba(30, 41, 59, 0.8);
+            border-radius: 12px;
+            padding: 14px;
+            border: 1px solid rgba(148, 163, 184, 0.14);
+            margin-top: 12px;
+        }
+        .mission-summary h3 {
+            margin: 0 0 8px;
+            font-size: 1rem;
+        }
+        .mission-steps {
+            margin: 12px 0 0;
+            padding: 0;
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .mission-steps li {
+            padding: 10px;
+            border-radius: 10px;
+            background: rgba(15, 23, 42, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.1);
+            display: flex;
+            justify-content: space-between;
+            gap: 10px;
+        }
+        .mission-history {
+            margin-top: 16px;
+        }
+        .mission-history h4 {
+            margin: 0 0 6px;
+            font-size: 0.9rem;
+            color: #94a3b8;
+        }
+        .mission-history ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .mission-history li {
+            font-size: 0.85rem;
+            color: #cbd5f5;
+        }
+        .systems-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 12px;
+        }
+        .system-card {
+            border-radius: 12px;
+            padding: 12px;
+            background: rgba(15, 23, 42, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+        }
+        .system-card h3 {
+            margin: 0;
+            font-size: 0.95rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .system-card p {
+            margin: 6px 0 0;
+            font-size: 0.85rem;
+            color: #94a3b8;
+        }
+        .status-nominal { color: #86efac; }
+        .status-maintenance { color: #fbbf24; }
+        .status-fault { color: #f87171; }
+        .status-booting { color: #93c5fd; }
+        #agents-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 12px;
+        }
+        .agent-card {
+            background: rgba(15, 23, 42, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 12px;
+            padding: 14px;
+        }
+        .agent-card h3 {
+            margin: 0 0 6px;
+            font-size: 1rem;
+        }
+        .agent-card p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: #94a3b8;
+        }
+        .timeline-container {
+            height: calc(100vh - 160px);
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+        }
+        .timeline-list {
+            flex: 1;
+            overflow-y: auto;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding-right: 6px;
+        }
+        .timeline-item {
+            padding: 12px 16px;
+            border-radius: 12px;
+            background: rgba(15, 23, 42, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+        }
+        .timeline-item .meta {
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-bottom: 6px;
+        }
+        .timeline-item .message {
+            font-size: 0.95rem;
+        }
+        @media (max-width: 980px) {
+            main.layout {
+                grid-template-columns: 1fr;
+            }
+            .timeline-container {
+                height: auto;
+                max-height: 480px;
+            }
+            .timeline-list {
+                flex-direction: column;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>🚀 AERUM Mission Control Dashboard</h1>
+        <p>Orchestrate boot operations, monitor missions, and observe live telemetry.</p>
+    </header>
+    <main class="layout">
+        <div class="stack">
+            <section class="panel" id="boot-panel">
+                <div class="panel-controls">
+                    <h2>Boot Control</h2>
+                    <span id="boot-status" class="status-badge status-idle">Idle</span>
+                </div>
+                <button id="boot-button" class="primary">Start Boot Sequence</button>
+                <ul id="boot-stages" class="boot-stages"></ul>
+                <div class="boot-message" id="boot-message"></div>
+            </section>
+
+            <section class="panel" id="mission-panel">
+                <div class="panel-controls">
+                    <h2>Mission Control</h2>
+                    <button id="mission-button" class="primary" disabled>Launch Mission</button>
+                </div>
+                <select id="mission-select" disabled></select>
+                <div class="mission-summary" id="mission-summary"></div>
+                <div class="mission-history">
+                    <h4>Recent Missions</h4>
+                    <ul id="mission-history"></ul>
+                </div>
+            </section>
+
+            <section class="panel" id="systems-panel">
+                <div class="panel-controls">
+                    <h2>Systems</h2>
+                </div>
+                <div class="systems-grid" id="systems-grid"></div>
+            </section>
+
+            <section class="panel" id="agents-panel">
+                <div class="panel-controls">
+                    <h2>Agents</h2>
+                </div>
+                <div id="agents-list"></div>
+            </section>
+        </div>
+
+        <section class="panel timeline" id="timeline-panel">
+            <div class="panel-controls">
+                <h2>Event Timeline</h2>
+            </div>
+            <div class="timeline-container">
+                <ul id="timeline-list" class="timeline-list"></ul>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        const bootButton = document.getElementById('boot-button');
+        const bootStatus = document.getElementById('boot-status');
+        const bootStagesEl = document.getElementById('boot-stages');
+        const bootMessageEl = document.getElementById('boot-message');
+
+        const missionSelect = document.getElementById('mission-select');
+        const missionButton = document.getElementById('mission-button');
+        const missionSummary = document.getElementById('mission-summary');
+        const missionHistoryList = document.getElementById('mission-history');
+
+        const systemsGrid = document.getElementById('systems-grid');
+        const agentsList = document.getElementById('agents-list');
+        const timelineList = document.getElementById('timeline-list');
+
+        const statusClass = (status) => `status-${(status || 'idle').toLowerCase()}`;
+        let isBootComplete = false;
+        let missionActive = false;
+
+        function setBootStatus(status, message) {
+            const cls = statusClass(status);
+            bootStatus.className = `status-badge ${cls}`;
+            bootStatus.textContent = status ? status.toUpperCase() : 'UNKNOWN';
+            isBootComplete = status === 'complete';
+            bootButton.disabled = status === 'running' || status === 'complete';
+            missionSelect.disabled = !isBootComplete || missionActive;
+            missionButton.disabled = !isBootComplete || missionActive || missionSelect.value === '';
+            if (message) {
+                bootMessageEl.textContent = message;
+            } else {
+                bootMessageEl.textContent = '';
+            }
+        }
+
+        function renderBootStages(boot) {
+            bootStagesEl.innerHTML = '';
+            (boot.stages || []).forEach(stage => {
+                const li = document.createElement('li');
+                const name = document.createElement('span');
+                name.textContent = stage.name;
+                name.className = 'name';
+                const badge = document.createElement('span');
+                const stageStatus = stage.status || 'pending';
+                badge.className = `status-badge ${statusClass(stageStatus)}`;
+                badge.textContent = stageStatus.toUpperCase();
+                li.appendChild(name);
+                li.appendChild(badge);
+                if (stage.message) {
+                    const detail = document.createElement('div');
+                    detail.textContent = stage.message;
+                    detail.style.fontSize = '0.75rem';
+                    detail.style.color = '#94a3b8';
+                    detail.style.marginTop = '6px';
+                    detail.style.gridColumn = '1 / -1';
+                    li.appendChild(detail);
+                }
+                bootStagesEl.appendChild(li);
+            });
+        }
+
+        function renderMission(missionsState) {
+            const current = missionsState.current;
+            missionSummary.innerHTML = '';
+            missionActive = Boolean(current && current.status === 'running');
+            missionSelect.disabled = !isBootComplete || missionActive;
+            missionButton.disabled = !isBootComplete || missionActive || missionSelect.value === '';
+            if (current) {
+                const title = document.createElement('h3');
+                title.textContent = current.name || current.file;
+                const statusEl = document.createElement('div');
+                statusEl.className = `status-badge ${statusClass(current.status)}`;
+                statusEl.textContent = (current.status || 'unknown').toUpperCase();
+                const wrapper = document.createElement('div');
+                wrapper.style.display = 'flex';
+                wrapper.style.justifyContent = 'space-between';
+                wrapper.style.alignItems = 'center';
+                wrapper.appendChild(title);
+                wrapper.appendChild(statusEl);
+                missionSummary.appendChild(wrapper);
+                if (current.message) {
+                    const msg = document.createElement('p');
+                    msg.textContent = current.message;
+                    msg.style.color = '#94a3b8';
+                    msg.style.margin = '8px 0 0';
+                    missionSummary.appendChild(msg);
+                }
+                const steps = document.createElement('ul');
+                steps.className = 'mission-steps';
+                (current.steps || []).forEach(step => {
+                    const li = document.createElement('li');
+                    const name = document.createElement('span');
+                    name.textContent = step.name;
+                    const badge = document.createElement('span');
+                    badge.className = `status-badge ${statusClass(step.status)}`;
+                    badge.textContent = (step.status || 'pending').toUpperCase();
+                    li.appendChild(name);
+                    li.appendChild(badge);
+                    if (step.detail) {
+                        const detail = document.createElement('div');
+                        detail.textContent = step.detail;
+                        detail.style.fontSize = '0.75rem';
+                        detail.style.color = '#94a3b8';
+                        detail.style.marginTop = '4px';
+                        detail.style.gridColumn = '1 / -1';
+                        li.appendChild(detail);
+                    }
+                    steps.appendChild(li);
+                });
+                missionSummary.appendChild(steps);
+            } else {
+                const idle = document.createElement('p');
+                idle.textContent = 'No mission active. Select a mission file to prepare for launch.';
+                idle.style.color = '#94a3b8';
+                missionSummary.appendChild(idle);
+            }
+            missionHistoryList.innerHTML = '';
+            (missionsState.history || []).forEach(entry => {
+                const li = document.createElement('li');
+                li.textContent = `${entry.name || entry.file} — ${(entry.status || 'unknown').toUpperCase()} (${new Date(entry.completed_at || entry.started_at).toLocaleString()})`;
+                missionHistoryList.appendChild(li);
+            });
+        }
+
+        function renderSystems(systems) {
+            systemsGrid.innerHTML = '';
+            const entries = Object.values(systems || {});
+            if (!entries.length) {
+                const placeholder = document.createElement('p');
+                placeholder.textContent = 'Awaiting telemetry...';
+                placeholder.style.color = '#94a3b8';
+                systemsGrid.appendChild(placeholder);
+                return;
+            }
+            entries.forEach(system => {
+                const card = document.createElement('div');
+                card.className = 'system-card';
+                const title = document.createElement('h3');
+                title.textContent = system.name.toUpperCase();
+                title.classList.add(statusClass(system.status));
+                const detail = document.createElement('p');
+                detail.textContent = system.detail || 'No detail available';
+                card.appendChild(title);
+                card.appendChild(detail);
+                systemsGrid.appendChild(card);
+            });
+        }
+
+        function renderAgents(agents) {
+            agentsList.innerHTML = '';
+            agents.forEach(agent => {
+                const card = document.createElement('div');
+                card.className = 'agent-card';
+                const header = document.createElement('h3');
+                header.textContent = agent.agent;
+                const status = document.createElement('p');
+                status.textContent = agent.status || 'No status';
+                const timestamp = document.createElement('p');
+                if (agent.timestamp) {
+                    timestamp.textContent = `Updated ${new Date(agent.timestamp).toLocaleTimeString()}`;
+                }
+                agentsList.appendChild(card);
+                card.appendChild(header);
+                card.appendChild(status);
+                card.appendChild(timestamp);
+                if (agent.health) {
+                    const health = document.createElement('p');
+                    health.textContent = `Health: ${agent.health}`;
+                    health.style.color = agent.health.toLowerCase() === 'failed' ? '#f87171' : '#bbf7d0';
+                    card.appendChild(health);
+                }
+            });
+        }
+
+        function renderTimeline(events) {
+            timelineList.innerHTML = '';
+            events.forEach(event => {
+                const item = createTimelineItem(event);
+                timelineList.appendChild(item);
+            });
+        }
+
+        function createTimelineItem(event) {
+            const item = document.createElement('li');
+            item.className = 'timeline-item';
+            const meta = document.createElement('div');
+            meta.className = 'meta';
+            meta.textContent = `${event.agent} • ${new Date(event.timestamp).toLocaleTimeString()} • ${event.category}`;
+            const message = document.createElement('div');
+            message.className = 'message';
+            message.textContent = event.message;
+            item.appendChild(meta);
+            item.appendChild(message);
+            return item;
+        }
+
+        function prependTimeline(event) {
+            const item = createTimelineItem(event);
+            timelineList.insertBefore(item, timelineList.firstChild);
+        }
+
+        function hydrateState(data) {
+            setBootStatus(data.boot?.status || 'idle', data.boot?.message);
+            renderBootStages(data.boot || {});
+            renderMission(data.missions || {});
+            renderSystems(data.systems || {});
+            renderAgents(data.agents || []);
+            renderTimeline(data.events || []);
+        }
+
+        async function loadState() {
+            const res = await fetch('/api/state');
+            const data = await res.json();
+            hydrateState(data);
+        }
+
+        async function loadMissions() {
+            const res = await fetch('/api/missions');
+            const data = await res.json();
+            missionSelect.innerHTML = '';
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = 'Select mission file';
+            missionSelect.appendChild(placeholder);
+            (data.missions || []).forEach(mission => {
+                const opt = document.createElement('option');
+                opt.value = mission.file;
+                opt.textContent = mission.name;
+                missionSelect.appendChild(opt);
+            });
+            missionSelect.disabled = !isBootComplete || missionActive;
+            missionButton.disabled = !isBootComplete || missionActive || missionSelect.value === '';
+        }
+
+        bootButton.addEventListener('click', async () => {
+            bootButton.disabled = true;
+            setBootStatus('running');
+            await fetch('/api/boot', { method: 'POST' });
+        });
+
+        missionSelect.addEventListener('change', () => {
+            missionButton.disabled = missionSelect.value === '';
+        });
+
+        missionButton.addEventListener('click', async () => {
+            if (!missionSelect.value) return;
+            missionButton.disabled = true;
+            await fetch('/api/missions/select', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ filename: missionSelect.value }),
+            });
+        });
+
+        function connectStream() {
+            const source = new EventSource('/api/stream');
+            source.onmessage = (event) => {
+                const payload = JSON.parse(event.data);
+                if (payload.type === 'event') {
+                    prependTimeline(payload.event);
+                }
+                if (payload.type === 'status') {
+                    // handled by aggregated updates
+                }
+                if (payload.type === 'agents') {
+                    renderAgents(payload.agents);
+                }
+                if (payload.type === 'boot') {
+                    setBootStatus(payload.boot.status, payload.boot.message);
+                    renderBootStages(payload.boot);
+                }
+                if (payload.type === 'systems') {
+                    renderSystems(payload.systems);
+                }
+                if (payload.type === 'mission') {
+                    renderMission(payload.mission);
+                }
+            };
+            source.onerror = () => {
+                source.close();
+                setTimeout(connectStream, 3000);
+            };
+        }
+
+        loadState();
+        loadMissions();
+        connectStream();
+    </script>
+</body>
+</html>

--- a/src/interface/dashboard.py
+++ b/src/interface/dashboard.py
@@ -7,7 +7,8 @@ from typing import Optional
 
 from flask import Flask, Response, jsonify, request, stream_with_context
 
-from .event_store import event_store, EventStore
+from .event_store import EventStore, event_store
+from .runtime_controller import RuntimeController
 
 
 def _load_static_page() -> str:
@@ -20,8 +21,31 @@ def _load_static_page() -> str:
     )
 
 
-def create_app(store: Optional[EventStore] = None) -> Flask:
+class _StoreOnlyController:
+    """Fallback controller that only exposes read-only state."""
+
+    def __init__(self, store: EventStore):
+        self._store = store
+
+    def list_missions(self):  # pragma: no cover - simple fallback
+        return []
+
+    def get_state_snapshot(self):
+        return self._store.get_state_snapshot()
+
+    def start_boot(self):  # pragma: no cover - simple fallback
+        return False, "Runtime controller unavailable"
+
+    def start_mission(self, _: str):  # pragma: no cover - simple fallback
+        return False, "Runtime controller unavailable"
+
+
+def create_app(
+    store: Optional[EventStore] = None,
+    controller: Optional[RuntimeController] = None,
+) -> Flask:
     store = store or event_store
+    controller = controller or _StoreOnlyController(store)
     app = Flask(__name__)
 
     page_cache = {"html": _load_static_page()}
@@ -48,6 +72,30 @@ def create_app(store: Optional[EventStore] = None) -> Flask:
     def api_agents() -> Response:
         return jsonify({"agents": store.get_statuses()})
 
+    @app.route("/api/state")
+    def api_state() -> Response:
+        return jsonify(controller.get_state_snapshot())
+
+    @app.route("/api/missions")
+    def api_missions() -> Response:
+        return jsonify({"missions": controller.list_missions()})
+
+    @app.route("/api/boot", methods=["POST"])
+    def api_boot() -> Response:
+        success, message = controller.start_boot()
+        status = 202 if success else 400
+        return jsonify({"success": success, "message": message}), status
+
+    @app.route("/api/missions/select", methods=["POST"])
+    def api_mission_select() -> Response:
+        payload = request.get_json(silent=True) or {}
+        filename = payload.get("filename")
+        if not filename:
+            return jsonify({"success": False, "message": "filename is required"}), 400
+        success, message = controller.start_mission(filename)
+        status = 202 if success else 400
+        return jsonify({"success": success, "message": message}), status
+
     @app.route("/api/stream")
     def api_stream() -> Response:
         def generate():
@@ -68,11 +116,14 @@ def create_app(store: Optional[EventStore] = None) -> Flask:
     return app
 
 
-def launch_dashboard(store: Optional[EventStore] = None) -> threading.Thread:
+def launch_dashboard(
+    store: Optional[EventStore] = None,
+    controller: Optional[RuntimeController] = None,
+) -> threading.Thread:
     """Start the dashboard web server in a background thread."""
 
     store = store or event_store
-    app = create_app(store)
+    app = create_app(store, controller=controller)
     port = int(os.getenv("DASHBOARD_PORT", "5000"))
 
     def run_app():

--- a/src/interface/event_store.py
+++ b/src/interface/event_store.py
@@ -1,9 +1,10 @@
+import copy
 import json
 import threading
 from collections import deque
 from datetime import datetime
 from queue import Queue
-from typing import Deque, Dict, List, Optional
+from typing import Deque, Dict, Iterable, List, Optional
 
 
 class EventStore:
@@ -15,6 +16,18 @@ class EventStore:
         self._lock = threading.Lock()
         self._subscribers: List[Queue] = []
         self._counter = 0
+        self._boot_state: Dict[str, dict] = {
+            "status": "idle",
+            "started_at": None,
+            "completed_at": None,
+            "message": None,
+            "stages": [],
+        }
+        self._systems_state: Dict[str, dict] = {}
+        self._missions_state: Dict[str, Optional[dict]] = {
+            "current": None,
+            "history": [],
+        }
 
     def _next_id(self) -> int:
         with self._lock:
@@ -55,18 +68,8 @@ class EventStore:
         }
         with self._lock:
             self._events.append(event)
-            self._statuses[agent] = {
-                "agent": agent,
-                "status": message,
-                "timestamp": ts,
-            }
         self._broadcast({"type": "event", "event": event})
-        self._broadcast(
-            {
-                "type": "status",
-                "status": self._statuses[agent],
-            }
-        )
+        self._update_agent_entry(agent, status=message, timestamp=ts)
         return event
 
     def get_events(self, *, limit: Optional[int] = None, offset: int = 0) -> List[dict]:
@@ -84,6 +87,263 @@ class EventStore:
     def get_statuses(self) -> List[dict]:
         with self._lock:
             return list(self._statuses.values())
+
+    # ------------------------------------------------------------------
+    # Agent state helpers
+
+    def _update_agent_entry(
+        self,
+        agent: str,
+        *,
+        status: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        health: Optional[str] = None,
+    ) -> dict:
+        ts = timestamp or datetime.utcnow().isoformat()
+        with self._lock:
+            current = copy.deepcopy(self._statuses.get(agent, {"agent": agent}))
+            if status is not None:
+                current["status"] = status
+                current["timestamp"] = ts
+            elif "timestamp" not in current:
+                current["timestamp"] = ts
+            if health is not None:
+                current["health"] = health
+            self._statuses[agent] = current
+            snapshot = list(self._statuses.values())
+        self._broadcast({"type": "status", "status": current})
+        self._broadcast({"type": "agents", "agents": snapshot})
+        return current
+
+    def set_agent_state(
+        self,
+        agent: str,
+        *,
+        status: Optional[str] = None,
+        health: Optional[str] = None,
+    ) -> dict:
+        return self._update_agent_entry(agent, status=status, health=health)
+
+    # ------------------------------------------------------------------
+    # Boot state helpers
+
+    def begin_boot(self, stages: Iterable[str]) -> dict:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            self._boot_state = {
+                "status": "running",
+                "started_at": now,
+                "completed_at": None,
+                "message": None,
+                "stages": [
+                    {
+                        "name": stage,
+                        "status": "pending",
+                        "message": None,
+                        "started_at": None,
+                        "completed_at": None,
+                    }
+                    for stage in stages
+                ],
+            }
+            boot_copy = copy.deepcopy(self._boot_state)
+        self._broadcast({"type": "boot", "boot": boot_copy})
+        return boot_copy
+
+    def _find_boot_stage(self, name: str) -> dict:
+        for stage in self._boot_state.get("stages", []):
+            if stage.get("name") == name:
+                return stage
+        stage = {
+            "name": name,
+            "status": "pending",
+            "message": None,
+            "started_at": None,
+            "completed_at": None,
+        }
+        self._boot_state.setdefault("stages", []).append(stage)
+        return stage
+
+    def update_boot_stage(
+        self,
+        name: str,
+        status: str,
+        *,
+        message: Optional[str] = None,
+    ) -> dict:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            stage = self._find_boot_stage(name)
+            stage["status"] = status
+            if message is not None:
+                stage["message"] = message
+            if status == "running" and stage.get("started_at") is None:
+                stage["started_at"] = now
+            if status in {"complete", "failed"}:
+                stage["completed_at"] = now
+            boot_copy = copy.deepcopy(self._boot_state)
+        self._broadcast({"type": "boot", "boot": boot_copy})
+        return boot_copy
+
+    def finalize_boot(self, status: str, *, message: Optional[str] = None) -> dict:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            self._boot_state["status"] = status
+            self._boot_state["completed_at"] = now
+            if message is not None:
+                self._boot_state["message"] = message
+            boot_copy = copy.deepcopy(self._boot_state)
+        self._broadcast({"type": "boot", "boot": boot_copy})
+        return boot_copy
+
+    def reset_boot(self) -> dict:
+        with self._lock:
+            self._boot_state = {
+                "status": "idle",
+                "started_at": None,
+                "completed_at": None,
+                "message": None,
+                "stages": [],
+            }
+            boot_copy = copy.deepcopy(self._boot_state)
+        self._broadcast({"type": "boot", "boot": boot_copy})
+        return boot_copy
+
+    # ------------------------------------------------------------------
+    # Systems telemetry
+
+    def set_system_state(
+        self,
+        system: str,
+        status: str,
+        *,
+        detail: Optional[str] = None,
+    ) -> dict:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            entry = {
+                "name": system,
+                "status": status,
+                "detail": detail,
+                "updated_at": now,
+            }
+            self._systems_state[system] = entry
+            systems_copy = copy.deepcopy(self._systems_state)
+        self._broadcast({"type": "systems", "systems": systems_copy})
+        return entry
+
+    # ------------------------------------------------------------------
+    # Mission state helpers
+
+    def begin_mission(self, *, file: str, name: str) -> dict:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            current = {
+                "file": file,
+                "name": name,
+                "status": "running",
+                "started_at": now,
+                "completed_at": None,
+                "message": None,
+                "steps": [],
+            }
+            self._missions_state["current"] = current
+            mission_copy = copy.deepcopy(self._missions_state)
+        self._broadcast({"type": "mission", "mission": mission_copy})
+        return mission_copy
+
+    def update_mission_step(
+        self,
+        step: str,
+        status: str,
+        *,
+        detail: Optional[str] = None,
+    ) -> Optional[dict]:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            current = self._missions_state.get("current")
+            if not current:
+                return None
+            steps = current.setdefault("steps", [])
+            for entry in steps:
+                if entry.get("name") == step:
+                    target = entry
+                    break
+            else:
+                target = {
+                    "name": step,
+                    "status": "pending",
+                    "detail": None,
+                    "started_at": None,
+                    "completed_at": None,
+                }
+                steps.append(target)
+            target["status"] = status
+            if detail is not None:
+                target["detail"] = detail
+            if status == "running" and target.get("started_at") is None:
+                target["started_at"] = now
+            if status in {"complete", "failed", "skipped"}:
+                target["completed_at"] = now
+            mission_copy = copy.deepcopy(self._missions_state)
+        self._broadcast({"type": "mission", "mission": mission_copy})
+        return target
+
+    def update_mission_status(
+        self,
+        status: str,
+        *,
+        message: Optional[str] = None,
+    ) -> Optional[dict]:
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            current = self._missions_state.get("current")
+            if not current:
+                return None
+            current["status"] = status
+            if message is not None:
+                current["message"] = message
+            if status in {"complete", "failed", "aborted"}:
+                current["completed_at"] = now
+                history = self._missions_state.setdefault("history", [])
+                history.insert(0, copy.deepcopy(current))
+                self._missions_state["history"] = history[:10]
+            mission_copy = copy.deepcopy(self._missions_state)
+        self._broadcast({"type": "mission", "mission": mission_copy})
+        return mission_copy
+
+    # ------------------------------------------------------------------
+    # Snapshot helpers
+
+    def get_boot_state(self) -> dict:
+        with self._lock:
+            return copy.deepcopy(self._boot_state)
+
+    def get_systems_state(self) -> Dict[str, dict]:
+        with self._lock:
+            return copy.deepcopy(self._systems_state)
+
+    def get_missions_state(self) -> dict:
+        with self._lock:
+            return copy.deepcopy(self._missions_state)
+
+    def get_state_snapshot(self, *, events_limit: int = 200) -> dict:
+        with self._lock:
+            events = list(self._events)
+            events.reverse()
+            if events_limit is not None:
+                events = events[:events_limit]
+            statuses = list(self._statuses.values())
+            boot = copy.deepcopy(self._boot_state)
+            systems = copy.deepcopy(self._systems_state)
+            missions = copy.deepcopy(self._missions_state)
+        return {
+            "events": events,
+            "agents": statuses,
+            "boot": boot,
+            "systems": systems,
+            "missions": missions,
+        }
 
     def subscribe(self) -> Queue:
         q: Queue = Queue()

--- a/src/interface/runtime_controller.py
+++ b/src/interface/runtime_controller.py
@@ -1,0 +1,251 @@
+"""Runtime controller orchestrating boot and mission lifecycle."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from agents.mission_lead import MissionLead
+from agents.mission_specialist import MissionSpecialist
+from agents.monitoring_agent import MonitoringAgent
+from agents.orbital_engineer import OrbitalEngineer
+from agents.spacecraft_technician import SpacecraftTechnician
+from interface.event_store import EventStore, event_store
+from utils.logger import Logger
+from utils.message_bus import MessageBus
+
+
+def wrap_logger_for_ui(logger: Logger, store: EventStore = event_store) -> None:
+    """Proxy the logger so log lines are mirrored into the UI event store."""
+
+    original_log = logger.log
+
+    def ui_log(agent: str, message: str) -> None:
+        original_log(agent, message)
+        store.record_event(agent, message)
+
+    logger.log = ui_log  # type: ignore[assignment]
+
+
+class RuntimeController:
+    """Coordinates background agents, boot sequencing, and mission execution."""
+
+    def __init__(self, *, store: Optional[EventStore] = None) -> None:
+        self.store = store or event_store
+        self.logger = Logger()
+        wrap_logger_for_ui(self.logger, self.store)
+        self.bus = MessageBus()
+
+        self._boot_lock = threading.Lock()
+        self._mission_lock = threading.Lock()
+        self._boot_thread: Optional[threading.Thread] = None
+        self._mission_thread: Optional[threading.Thread] = None
+        self._boot_complete = threading.Event()
+        self._mission_agents_started = False
+
+        self._technician = SpacecraftTechnician(self.logger, self.bus)
+        self._monitor = MonitoringAgent(self.logger, self.bus)
+        self._mission_lead: Optional[MissionLead] = None
+        self._engineer: Optional[OrbitalEngineer] = None
+        self._specialist: Optional[MissionSpecialist] = None
+
+        self._background_threads: List[threading.Thread] = []
+        self._start_background_agent(self._technician.run, "SpacecraftTechnician")
+        self._start_background_agent(self._monitor.run, "SystemMonitor")
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def list_missions(self) -> List[Dict[str, str]]:
+        missions: List[Dict[str, str]] = []
+        missions_dir = Path("missions")
+        for path in sorted(missions_dir.glob("*.json")):
+            name = path.stem.replace("_", " ")
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                name = data.get("name") or name
+            except Exception:
+                pass
+            missions.append({"file": path.name, "name": name})
+        return missions
+
+    def get_state_snapshot(self) -> dict:
+        return self.store.get_state_snapshot()
+
+    def start_boot(self) -> Tuple[bool, Optional[str]]:
+        with self._boot_lock:
+            boot_state = self.store.get_boot_state()
+            if boot_state.get("status") == "running":
+                return False, "Boot sequence already running"
+            if boot_state.get("status") == "complete":
+                return False, "Boot sequence already complete"
+            self.store.reset_boot()
+            self._boot_complete.clear()
+            self._boot_thread = threading.Thread(target=self._boot_worker, daemon=True)
+            self._boot_thread.start()
+        return True, None
+
+    def start_mission(self, mission_file: str) -> Tuple[bool, Optional[str]]:
+        missions_dir = Path("missions")
+        mission_path = missions_dir / mission_file
+        if not mission_path.exists():
+            return False, "Mission file not found"
+        if not self._boot_complete.is_set():
+            return False, "Boot sequence must complete before launching a mission"
+        with self._mission_lock:
+            if self._mission_thread and self._mission_thread.is_alive():
+                return False, "A mission is already in progress"
+            if not self._mission_agents_started:
+                self._start_mission_agents()
+
+            mission_name = mission_path.stem.replace("_", " ")
+            try:
+                data = json.loads(mission_path.read_text(encoding="utf-8"))
+                mission_name = data.get("name") or mission_name
+            except Exception:
+                pass
+
+            self.store.begin_mission(file=mission_path.name, name=mission_name)
+
+            self._mission_thread = threading.Thread(
+                target=self._mission_worker,
+                args=(mission_path.name,),
+                daemon=True,
+            )
+            self._mission_thread.start()
+        return True, None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _start_background_agent(self, target, agent_name: str) -> None:
+        thread = threading.Thread(target=target, daemon=True)
+        thread.start()
+        self._background_threads.append(thread)
+        self.store.set_agent_state(agent_name, status="Online")
+
+    def _start_mission_agents(self) -> None:
+        self._engineer = OrbitalEngineer(self.logger, self.bus)
+        self._specialist = MissionSpecialist(self.logger, self.bus)
+        self._mission_lead = MissionLead(self.logger, self.bus)
+
+        self._start_background_agent(self._engineer.run, "OrbitalEngineer")
+        self._start_background_agent(self._specialist.run, "MissionSpecialist")
+        self.store.set_agent_state("MissionLead", status="Ready for missions")
+        self._mission_agents_started = True
+
+    def _mission_worker(self, mission_file: str) -> None:
+        assert self._mission_lead is not None
+        try:
+            self._mission_lead.run(mission_file)
+            missions_state = self.store.get_missions_state()
+            current = missions_state.get("current")
+            if current and current.get("status") == "running":
+                self.store.update_mission_status("complete", message="Mission finished")
+        except Exception as exc:  # pragma: no cover - runtime safety
+            self.logger.log("MissionLead", f"Mission execution crashed: {exc}")
+            self.store.update_mission_status("failed", message=str(exc))
+
+    def _boot_worker(self) -> None:
+        stages = ["power", "comms"]
+        required_agents = ["SpacecraftTechnician", "SystemMonitor"]
+        timeout = 5
+
+        self.store.begin_boot(stages)
+        for system in stages:
+            self.store.set_system_state(system, "pending", detail="Awaiting boot")
+        self.store.set_agent_state("MissionLead", status="Coordinating boot")
+
+        success = True
+        for system in stages:
+            action = f"boot_{system}"
+            while self.bus.fetch("MissionLead"):
+                pass  # Drain inbox from previous stage
+            self.logger.log("MissionLead", f"Action: {action}")
+            self.store.update_boot_stage(system, "running", message=f"Booting {system}")
+            for agent_name in required_agents:
+                self.bus.send("MissionLead", agent_name, action)
+
+            start = time.time()
+            acknowledged = set()
+            failure_reason: Optional[str] = None
+
+            while time.time() - start < timeout and acknowledged != set(required_agents):
+                messages = self.bus.fetch("MissionLead")
+                for message in messages:
+                    sender = message.get("from")
+                    content = message.get("content", "")
+                    if isinstance(content, str) and content == f"TASK_COMPLETE: {action}":
+                        acknowledged.add(sender)
+                        self.logger.log("MissionLead", f"Acknowledged {action} by {sender}")
+                    elif isinstance(content, str) and content.startswith("FAILURE:"):
+                        payload = content.split("FAILURE:", 1)[1].strip()
+                        failure_action, _, reason = payload.partition("|")
+                        failure_action = failure_action.strip()
+                        reason = reason.strip() or "Agent reported failure"
+                        self.logger.log(
+                            "MissionLead",
+                            f"Failure reported by {sender} for {failure_action}: {reason}",
+                        )
+                        if failure_action == action:
+                            acknowledged.discard(sender)
+                            failure_reason = reason
+                            self.store.update_boot_stage(
+                                system,
+                                "failed",
+                                message=f"Failure reported: {reason}",
+                            )
+                            break
+                    elif isinstance(content, str) and content.startswith("SYSTEM_FAILURE:"):
+                        failure_type = content.split(":", 1)[1].strip()
+                        self.logger.log(
+                            "MissionLead",
+                            f"Boot failure detected: {failure_type}",
+                        )
+                        failure_reason = f"System failure: {failure_type}"
+                        self.store.update_boot_stage(
+                            system,
+                            "failed",
+                            message=failure_reason,
+                        )
+                        self.store.set_system_state(
+                            failure_type,
+                            "fault",
+                            detail="Failure detected during boot",
+                        )
+                        break
+                if failure_reason:
+                    break
+                time.sleep(0.1)
+
+            if acknowledged != set(required_agents):
+                missing = set(required_agents) - acknowledged
+                failure_reason = failure_reason or f"Missing acknowledgements: {', '.join(missing)}"
+                self.logger.log(
+                    "MissionLead",
+                    f"Boot incomplete. Missing acknowledgements from: {', '.join(missing)}",
+                )
+                self.store.update_boot_stage(
+                    system,
+                    "failed",
+                    message=failure_reason,
+                )
+                self.store.set_system_state(system, "fault", detail=failure_reason)
+                success = False
+                break
+
+            self.logger.log("MissionLead", f"{system.title()} subsystem boot confirmed.")
+            self.store.update_boot_stage(system, "complete", message="Subsystem nominal")
+            self.store.set_system_state(system, "nominal", detail="Subsystem nominal")
+
+        if success:
+            self.logger.log("MissionLead", "All systems nominal.")
+            self.store.finalize_boot("complete", message="All systems nominal")
+            self.store.set_agent_state("MissionLead", status="Boot complete")
+            self._boot_complete.set()
+        else:
+            self.store.finalize_boot("failed", message="Boot sequence failed")
+            self.store.set_agent_state("MissionLead", status="Boot failed")

--- a/src/main.py
+++ b/src/main.py
@@ -1,69 +1,51 @@
 import os
-import threading
 import time
-from utils.logger import Logger
-from utils.message_bus import MessageBus
-from agents.mission_lead import MissionLead
-from agents.orbital_engineer import OrbitalEngineer
-from agents.mission_specialist import MissionSpecialist
-from agents.spacecraft_technician import SpacecraftTechnician
-from agents.monitoring_agent import MonitoringAgent
+
 from interface.dashboard import launch_dashboard
-from interface.event_store import event_store
+from interface.runtime_controller import RuntimeController
 
 
-def wrap_logger_for_ui(logger):
-    """Proxy logger to capture log lines into the web dashboard event store."""
-
-    original_log = logger.log
-
-    def ui_log(agent, message):
-        original_log(agent, message)
-        event_store.record_event(agent, message)
-
-    logger.log = ui_log
-
-# Pre-mission boot sequence (unchanged)
 def run_boot_sequence(logger, bus, timeout=5):
-    """Sequentially boot subsystems with auto-repair and failure handling."""
+    """Sequentially boot subsystems with retry handling (legacy helper)."""
+
     subsystems = ["power", "comms"]
     required_agents = ["SpacecraftTechnician", "SystemMonitor"]
 
-    for sys in subsystems:
-        action = f"boot_{sys}"
-        while bus.fetch("MissionLead"): pass
+    for subsystem in subsystems:
+        action = f"boot_{subsystem}"
+        while bus.fetch("MissionLead"):
+            pass
         logger.log("MissionLead", f"Action: {action}")
         for agent in required_agents:
             bus.send("MissionLead", agent, action)
         start = time.time()
-        acked = set()
-        while time.time() - start < timeout and acked != set(required_agents):
-            msgs = bus.fetch("MissionLead")
-            for msg in msgs:
-                sender = msg.get("from")
-                content = msg.get("content", "")
+        acknowledgements = set()
+        failure_reason = None
+        while time.time() - start < timeout and acknowledgements != set(required_agents):
+            messages = bus.fetch("MissionLead")
+            for message in messages:
+                sender = message.get("from")
+                content = message.get("content", "")
                 if isinstance(content, str) and content == f"TASK_COMPLETE: {action}":
-                    acked.add(sender)
+                    acknowledgements.add(sender)
                     logger.log("MissionLead", f"Acknowledged {action} by {sender}")
                 elif isinstance(content, str) and content.startswith("FAILURE:"):
                     payload = content.split("FAILURE:", 1)[1].strip()
-                    failure_action = payload
-                    failure_reason = "unknown"
-                    if "|" in payload:
-                        parts = payload.split("|", 1)
-                        failure_action = parts[0].strip()
-                        failure_reason = parts[1].strip()
+                    failure_action, _, reason = payload.partition("|")
+                    failure_action = failure_action.strip()
+                    reason = reason.strip() or "unknown"
                     if failure_action == action:
+                        failure_reason = reason
                         agent_name = sender or "Unknown"
                         logger.log(
                             "MissionLead",
-                            f"Failure reported by {agent_name} for {action}: {failure_reason}",
+                            f"Failure reported by {agent_name} for {action}: {reason}",
                         )
-                        if sender in acked:
-                            acked.remove(sender)
+                        if sender in acknowledgements:
+                            acknowledgements.remove(sender)
                         if sender:
                             logger.log("MissionLead", f"Retrying {action} with {agent_name}")
-                            bus.send("MissionLead", agent_name, action)
+                            bus.send("MissionLead", sender, action)
                     else:
                         logger.log(
                             "MissionLead",
@@ -71,63 +53,42 @@ def run_boot_sequence(logger, bus, timeout=5):
                         )
                 elif isinstance(content, str) and content.startswith("SYSTEM_FAILURE:"):
                     failure = content.split(":", 1)[1].strip()
-                    if failure == sys:
+                    if failure == subsystem:
                         logger.log("MissionLead", f"Boot failure detected: {failure}")
                         fix_cmd = f"fix_{failure}"
                         logger.log("MissionLead", f"Delegating fix: {fix_cmd}")
-                        for a in required_agents:
-                            bus.send("MissionLead", a, fix_cmd)
+                        for agent in required_agents:
+                            bus.send("MissionLead", agent, fix_cmd)
             time.sleep(0.1)
-        if acked != set(required_agents):
-            missing = set(required_agents) - acked
-            logger.log("MissionLead", f"Boot incomplete. Missing acknowledgements from: {', '.join(missing)}")
+
+        if acknowledgements != set(required_agents):
+            missing = set(required_agents) - acknowledgements
+            logger.log(
+                "MissionLead",
+                f"Boot incomplete. Missing acknowledgements from: {', '.join(missing)}",
+            )
+            if failure_reason:
+                logger.log("MissionLead", f"Last failure reason: {failure_reason}")
             return False
+
     logger.log("MissionLead", "All systems nominal.")
     return True
 
-# Mission selection via console
-def select_mission():
-    files = [f for f in os.listdir('missions') if f.endswith('.json')]
-    print("📡 AERUM MISSION CONTROL")
-    print("Select a mission:\n")
-    for i, f in enumerate(files, 1):
-        print(f"[{i}] {f}")
-    while True:
-        try:
-            c = int(input("\n>> "))
-            if 1 <= c <= len(files):
-                return files[c-1]
-        except:
-            pass
-        print("Invalid selection.")
 
-if __name__ == "__main__":
-    logger = Logger()
-    wrap_logger_for_ui(logger)
-    bus = MessageBus()
+def main() -> None:
+    controller = RuntimeController()
+    launch_dashboard(store=controller.store, controller=controller)
 
-    tech = SpacecraftTechnician(logger, bus)
-    mon = MonitoringAgent(logger, bus)
-    threading.Thread(target=tech.run, daemon=True).start()
-    threading.Thread(target=mon.run, daemon=True).start()
+    port = os.getenv("DASHBOARD_PORT", "5000")
+    print(f"Dashboard running at http://localhost:{port}")
+    print("Open the dashboard to initiate the boot sequence and launch missions.")
 
-    if not run_boot_sequence(logger, bus):
-        exit(1)
-
-    mission = select_mission()
-    engineer = OrbitalEngineer(logger, bus)
-    specialist = MissionSpecialist(logger, bus)
-    threading.Thread(target=engineer.run, daemon=True).start()
-    threading.Thread(target=specialist.run, daemon=True).start()
-
-    lead = MissionLead(logger, bus)
-    threading.Thread(target=lead.run, args=(mission,), daemon=True).start()
-
-    launch_dashboard()
-
-    print("Dashboard running at http://localhost:{}".format(os.getenv("DASHBOARD_PORT", "5000")))
     try:
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
         print("\nShutting down AERUM controllers...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a runtime controller that launches core agents, exposes mission controls, and feeds the UI
- extend the event store with structured boot, system, mission, and agent state plus new REST endpoints
- rebuild the dashboard HTML/JS so operators can trigger boot, launch missions, and monitor telemetry directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d66954348324a201a18e6fc5b4e8