### PR TITLE
feat: migrate services to ZeroMQ architecture

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 flask
 whisper
 opencv-python
+pyzmq

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core package for AERUM services."""
+

--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -1,0 +1,6 @@
+"""Contracts for inter-service messaging."""
+
+from .messages import Command, Event, Health, Reply
+
+__all__ = ["Command", "Reply", "Event", "Health"]
+

--- a/src/core/contracts/messages.py
+++ b/src/core/contracts/messages.py
@@ -1,0 +1,73 @@
+"""Message contract definitions for ZeroMQ-based services."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional, Type, TypeVar
+
+
+def _default_timestamp() -> float:
+    return time.time()
+
+
+def _default_correlation_id() -> str:
+    return str(uuid.uuid4())
+
+
+T = TypeVar("T", bound="BaseMessage")
+
+
+class BaseMessage:
+    """Base helper for message contracts."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls: Type[T], data: str) -> T:
+        payload = json.loads(data)
+        return cls(**payload)  # type: ignore[arg-type]
+
+
+@dataclass(slots=True)
+class Command(BaseMessage):
+    src: str
+    dst: str
+    action: str
+    payload: Dict[str, Any]
+    correlation_id: str = field(default_factory=_default_correlation_id)
+    timestamp: float = field(default_factory=_default_timestamp)
+
+
+@dataclass(slots=True)
+class Reply(BaseMessage):
+    src: str
+    dst: str
+    status: str
+    payload: Dict[str, Any]
+    correlation_id: str
+    timestamp: float = field(default_factory=_default_timestamp)
+
+
+@dataclass(slots=True)
+class Event(BaseMessage):
+    src: str
+    level: str
+    topic: str
+    payload: Dict[str, Any]
+    timestamp: float = field(default_factory=_default_timestamp)
+
+
+@dataclass(slots=True)
+class Health(BaseMessage):
+    src: str
+    status: str
+    details: Optional[Dict[str, Any]] = None
+    timestamp: float = field(default_factory=_default_timestamp)
+

--- a/src/core/ipc/__init__.py
+++ b/src/core/ipc/__init__.py
@@ -1,0 +1,13 @@
+"""ZeroMQ IPC helpers."""
+
+from .zmq_bus import TOPIC_EVENTS, TOPIC_HEALTH, make_pub, make_rep, make_req, make_sub
+
+__all__ = [
+    "make_req",
+    "make_rep",
+    "make_pub",
+    "make_sub",
+    "TOPIC_EVENTS",
+    "TOPIC_HEALTH",
+]
+

--- a/src/core/ipc/zmq_bus.py
+++ b/src/core/ipc/zmq_bus.py
@@ -1,0 +1,58 @@
+"""Utilities for creating ZeroMQ sockets used across services."""
+
+from __future__ import annotations
+
+import zmq
+
+TOPIC_EVENTS = "events"
+TOPIC_HEALTH = "health"
+
+
+def make_req(ctx: zmq.Context, address: str) -> zmq.Socket:
+    """Create a REQ socket connected to the given address."""
+
+    socket = ctx.socket(zmq.REQ)
+    socket.connect(address)
+    return socket
+
+
+def make_rep(ctx: zmq.Context, address: str) -> zmq.Socket:
+    """Create a REP socket bound to the given address."""
+
+    socket = ctx.socket(zmq.REP)
+    socket.bind(address)
+    return socket
+
+
+def make_pub(ctx: zmq.Context, address: str, *, bind: bool = True) -> zmq.Socket:
+    """Create a PUB socket for the given address."""
+
+    socket = ctx.socket(zmq.PUB)
+    if bind:
+        socket.bind(address)
+    else:
+        socket.connect(address)
+    return socket
+
+
+def make_sub(
+    ctx: zmq.Context,
+    address: str,
+    topics: list[str] | None = None,
+    *,
+    bind: bool = False,
+) -> zmq.Socket:
+    """Create a SUB socket for the given address and subscribe to topics."""
+
+    socket = ctx.socket(zmq.SUB)
+    if bind:
+        socket.bind(address)
+    else:
+        socket.connect(address)
+    if not topics:
+        socket.setsockopt_string(zmq.SUBSCRIBE, "")
+    else:
+        for topic in topics:
+            socket.setsockopt_string(zmq.SUBSCRIBE, topic)
+    return socket
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,94 +1,83 @@
+"""Entry point to launch the service-oriented AERUM stack."""
+
+from __future__ import annotations
+
+import logging
 import os
+import signal
 import time
+from multiprocessing import Process
+from typing import Callable, List
 
-from interface.dashboard import launch_dashboard
-from interface.runtime_controller import RuntimeController
+import zmq
+
+from core.contracts import Command, Reply
+from core.ipc import make_req
+from services.datastore.main import main as datastore_main
+from services.mission_lead.main import main as mission_lead_main
+from services.technician.main import main as technician_main
+
+MISSION_LEAD_CLIENT_ADDRESS = os.getenv("MISSION_LEAD_CLIENT_ADDR", "tcp://127.0.0.1:5001")
 
 
-def run_boot_sequence(logger, bus, timeout=5):
-    """Sequentially boot subsystems with retry handling (legacy helper)."""
+def _start_process(target: Callable[[], None], name: str) -> Process:
+    process = Process(target=target, name=name, daemon=False)
+    process.start()
+    logging.info("Started %s (pid=%s)", name, process.pid)
+    return process
 
-    subsystems = ["power", "comms"]
-    required_agents = ["SpacecraftTechnician", "SystemMonitor"]
 
-    for subsystem in subsystems:
-        action = f"boot_{subsystem}"
-        while bus.fetch("MissionLead"):
-            pass
-        logger.log("MissionLead", f"Action: {action}")
-        for agent in required_agents:
-            bus.send("MissionLead", agent, action)
-        start = time.time()
-        acknowledgements = set()
-        failure_reason = None
-        while time.time() - start < timeout and acknowledgements != set(required_agents):
-            messages = bus.fetch("MissionLead")
-            for message in messages:
-                sender = message.get("from")
-                content = message.get("content", "")
-                if isinstance(content, str) and content == f"TASK_COMPLETE: {action}":
-                    acknowledgements.add(sender)
-                    logger.log("MissionLead", f"Acknowledged {action} by {sender}")
-                elif isinstance(content, str) and content.startswith("FAILURE:"):
-                    payload = content.split("FAILURE:", 1)[1].strip()
-                    failure_action, _, reason = payload.partition("|")
-                    failure_action = failure_action.strip()
-                    reason = reason.strip() or "unknown"
-                    if failure_action == action:
-                        failure_reason = reason
-                        agent_name = sender or "Unknown"
-                        logger.log(
-                            "MissionLead",
-                            f"Failure reported by {agent_name} for {action}: {reason}",
-                        )
-                        if sender in acknowledgements:
-                            acknowledgements.remove(sender)
-                        if sender:
-                            logger.log("MissionLead", f"Retrying {action} with {agent_name}")
-                            bus.send("MissionLead", sender, action)
-                    else:
-                        logger.log(
-                            "MissionLead",
-                            f"Received failure for {failure_action} from {sender} during {action}",
-                        )
-                elif isinstance(content, str) and content.startswith("SYSTEM_FAILURE:"):
-                    failure = content.split(":", 1)[1].strip()
-                    if failure == subsystem:
-                        logger.log("MissionLead", f"Boot failure detected: {failure}")
-                        fix_cmd = f"fix_{failure}"
-                        logger.log("MissionLead", f"Delegating fix: {fix_cmd}")
-                        for agent in required_agents:
-                            bus.send("MissionLead", agent, fix_cmd)
-            time.sleep(0.1)
-
-        if acknowledgements != set(required_agents):
-            missing = set(required_agents) - acknowledgements
-            logger.log(
-                "MissionLead",
-                f"Boot incomplete. Missing acknowledgements from: {', '.join(missing)}",
-            )
-            if failure_reason:
-                logger.log("MissionLead", f"Last failure reason: {failure_reason}")
-            return False
-
-    logger.log("MissionLead", "All systems nominal.")
-    return True
+def _send_demo_command() -> None:
+    ctx = zmq.Context.instance()
+    socket = make_req(ctx, MISSION_LEAD_CLIENT_ADDRESS)
+    try:
+        command = Command(
+            src="demo",
+            dst="mission_lead",
+            action="delegate",
+            payload={"target": "technician", "action": "noop", "payload": {}},
+        )
+        socket.send_string(command.to_json())
+        reply = Reply.from_json(socket.recv_string())
+        logging.info("Demo delegate reply: %s", reply.payload)
+    finally:
+        socket.close(linger=0)
 
 
 def main() -> None:
-    controller = RuntimeController()
-    launch_dashboard(store=controller.store, controller=controller)
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
 
-    port = os.getenv("DASHBOARD_PORT", "5000")
-    print(f"Dashboard running at http://localhost:{port}")
-    print("Open the dashboard to initiate the boot sequence and launch missions.")
+    processes: List[Process] = []
 
+    def shutdown(_signum: int, _frame) -> None:
+        logging.info("Shutting down service stack")
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in processes:
+            proc.join(timeout=2)
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    processes.append(_start_process(datastore_main, "datastore"))
+    # Give datastore time to bind the SUB socket before publishers connect.
+    time.sleep(0.5)
+    processes.append(_start_process(mission_lead_main, "mission_lead"))
+    processes.append(_start_process(technician_main, "technician"))
+
+    time.sleep(1.0)
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        print("\nShutting down AERUM controllers...")
+        _send_demo_command()
+    except Exception as exc:  # pragma: no cover - demo best effort
+        logging.error("Demo command failed: %s", exc)
+
+    logging.info("Service stack running. Press Ctrl+C to exit.")
+    while True:
+        time.sleep(1)
 
 
 if __name__ == "__main__":
     main()
+

--- a/src/services/_common/__init__.py
+++ b/src/services/_common/__init__.py
@@ -1,0 +1,6 @@
+"""Shared utilities for service processes."""
+
+from .base_service import BaseService
+
+__all__ = ["BaseService"]
+

--- a/src/services/_common/base_service.py
+++ b/src/services/_common/base_service.py
@@ -1,0 +1,146 @@
+"""Base service template for AERUM ZeroMQ services."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+import time
+from typing import Any, Callable
+
+import zmq
+
+from core.contracts import Command, Event, Health, Reply
+from core.ipc import TOPIC_EVENTS, TOPIC_HEALTH, make_pub, make_rep
+
+DEFAULT_EVENT_FEED = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
+
+
+class BaseService:
+    """Base class providing command handling and health publication."""
+
+    def __init__(
+        self,
+        name: str,
+        command_address: str,
+        *,
+        event_feed_address: str | None = None,
+        health_interval: float = 1.0,
+    ) -> None:
+        self.name = name
+        self.command_address = command_address
+        self.event_feed_address = event_feed_address or DEFAULT_EVENT_FEED
+        self.health_interval = health_interval
+
+        self._ctx = zmq.Context.instance()
+        self._rep = make_rep(self._ctx, self.command_address)
+        self._pub = make_pub(self._ctx, self.event_feed_address, bind=False)
+
+        self._running = threading.Event()
+        self._health_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Start the service, serving commands until stopped."""
+
+        self._running.set()
+        self._health_thread = threading.Thread(target=self._health_loop, daemon=True)
+        self._health_thread.start()
+        self._install_signal_handlers(self.stop)
+
+        logging.info("%s service ready on %s", self.name, self.command_address)
+
+        try:
+            while self._running.is_set():
+                try:
+                    payload = self._rep.recv_string()
+                except zmq.error.ZMQError as exc:
+                    if not self._running.is_set():
+                        break
+                    raise exc
+                self._process_command(payload)
+        finally:
+            self.stop()
+
+    def stop(self) -> None:
+        if not self._running.is_set():
+            return
+
+        self._running.clear()
+        logging.info("Stopping %s service", self.name)
+        self._rep.close(linger=0)
+        self._pub.close(linger=0)
+        if self._health_thread:
+            self._health_thread.join(timeout=1)
+
+    # ------------------------------------------------------------------
+    # Command processing
+    # ------------------------------------------------------------------
+    def _process_command(self, payload: str) -> None:
+        cmd: Command | None = None
+        try:
+            cmd = Command.from_json(payload)
+            reply = self.handle(cmd)
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.exception("Error handling command")
+            reply = Reply(
+                src=self.name,
+                dst=cmd.src if cmd else "unknown",
+                status="error",
+                payload={"error": str(exc)},
+                correlation_id=cmd.correlation_id if cmd else "",
+            )
+
+        self._rep.send_string(reply.to_json())
+        event_payload = {"reply": reply.to_dict()}
+        if cmd is not None:
+            event_payload["command"] = cmd.to_dict()
+        self.emit_event(
+            topic=f"command.{reply.status}",
+            payload=event_payload,
+            level="info" if reply.status == "ok" else "error",
+        )
+
+    # ------------------------------------------------------------------
+    # Hooks for subclasses
+    # ------------------------------------------------------------------
+    def handle(self, cmd: Command) -> Reply:  # pragma: no cover - abstract method
+        raise NotImplementedError
+
+    def health_details(self) -> dict[str, Any]:  # pragma: no cover - optional override
+        return {}
+
+    # ------------------------------------------------------------------
+    # Messaging helpers
+    # ------------------------------------------------------------------
+    def emit_event(self, topic: str, payload: dict[str, Any], level: str = "info") -> None:
+        event = Event(src=self.name, level=level, topic=topic, payload=payload)
+        self._pub.send_string(f"{TOPIC_EVENTS} {event.to_json()}")
+
+    def publish_health(self, status: str = "ok", details: dict[str, Any] | None = None) -> None:
+        health = Health(src=self.name, status=status, details=details or self.health_details())
+        self._pub.send_string(f"{TOPIC_HEALTH} {health.to_json()}")
+
+    # ------------------------------------------------------------------
+    # Background loops
+    # ------------------------------------------------------------------
+    def _health_loop(self) -> None:
+        while self._running.is_set():
+            self.publish_health()
+            time.sleep(self.health_interval)
+
+    # ------------------------------------------------------------------
+    # Signals
+    # ------------------------------------------------------------------
+    def _install_signal_handlers(self, cleanup: Callable[[], None]) -> None:
+        def handler(signum, _frame):  # pragma: no cover - best effort cleanup
+            logging.info("Signal %s received by %s", signum, self.name)
+            cleanup()
+            raise SystemExit(0)
+
+        signal.signal(signal.SIGINT, handler)
+        signal.signal(signal.SIGTERM, handler)
+

--- a/src/services/datastore/__init__.py
+++ b/src/services/datastore/__init__.py
@@ -1,0 +1,2 @@
+"""Datastore service package."""
+

--- a/src/services/datastore/main.py
+++ b/src/services/datastore/main.py
@@ -1,0 +1,121 @@
+"""Datastore service for persisting events and health telemetry."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sqlite3
+from contextlib import closing
+from typing import Callable
+
+import zmq
+
+from core.contracts import Event, Health
+from core.ipc import TOPIC_EVENTS, TOPIC_HEALTH, make_sub
+
+DB_PATH = os.getenv("AERUM_DB_PATH", "aerum.db")
+EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Initialise the SQLite database with required tables."""
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS events (
+                t REAL,
+                src TEXT,
+                level TEXT,
+                topic TEXT,
+                payload TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS health (
+                t REAL,
+                src TEXT,
+                status TEXT,
+                details TEXT
+            )
+            """
+        )
+        conn.commit()
+
+
+def _store_event(conn: sqlite3.Connection, event: Event) -> None:
+    conn.execute(
+        "INSERT INTO events (t, src, level, topic, payload) VALUES (?, ?, ?, ?, ?)",
+        (event.timestamp, event.src, event.level, event.topic, event.to_json()),
+    )
+
+
+def _store_health(conn: sqlite3.Connection, health: Health) -> None:
+    conn.execute(
+        "INSERT INTO health (t, src, status, details) VALUES (?, ?, ?, ?)",
+        (health.timestamp, health.src, health.status, health.to_json()),
+    )
+
+
+def _install_signal_handlers(cleanup: Callable[[], None]) -> None:
+    def handler(signum, _frame):  # pragma: no cover - signal handling is best-effort
+        logging.info("Received signal %s - shutting down datastore", signum)
+        cleanup()
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
+    logging.info("Starting datastore service. DB=%s feed=%s", DB_PATH, EVENT_FEED_ADDRESS)
+
+    init_db(DB_PATH)
+
+    ctx = zmq.Context.instance()
+    sub = make_sub(
+        ctx,
+        EVENT_FEED_ADDRESS,
+        topics=[TOPIC_EVENTS, TOPIC_HEALTH],
+        bind=True,
+    )
+
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    conn.isolation_level = None  # autocommit mode
+
+    def cleanup() -> None:
+        logging.info("Shutting down datastore service")
+        sub.close(linger=0)
+        conn.close()
+
+    _install_signal_handlers(cleanup)
+
+    try:
+        while True:
+            message = sub.recv_string()
+            try:
+                topic, payload = message.split(" ", 1)
+            except ValueError:
+                logging.warning("Malformed message: %s", message)
+                continue
+
+            if topic == TOPIC_EVENTS:
+                event = Event.from_json(payload)
+                _store_event(conn, event)
+            elif topic == TOPIC_HEALTH:
+                health = Health.from_json(payload)
+                _store_health(conn, health)
+            else:  # pragma: no cover - guards against future unknown topics
+                logging.debug("Ignoring unknown topic: %s", topic)
+            conn.commit()
+    finally:
+        cleanup()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/services/mission_lead/__init__.py
+++ b/src/services/mission_lead/__init__.py
@@ -1,0 +1,2 @@
+"""Mission lead service."""
+

--- a/src/services/mission_lead/main.py
+++ b/src/services/mission_lead/main.py
@@ -1,0 +1,126 @@
+"""Mission Lead service implemented as a BaseService subclass."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import zmq
+
+from core.contracts import Command, Reply
+from core.ipc import make_req
+from services._common import BaseService
+
+SERVICE_NAME = "mission_lead"
+COMMAND_ADDRESS = os.getenv("MISSION_LEAD_COMMAND_ADDR", "tcp://*:5001")
+EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
+TECHNICIAN_ADDR = os.getenv("TECHNICIAN_COMMAND_ADDR", "tcp://127.0.0.1:5002")
+
+
+class MissionLeadService(BaseService):
+    def __init__(self) -> None:
+        super().__init__(
+            name=SERVICE_NAME,
+            command_address=COMMAND_ADDRESS,
+            event_feed_address=EVENT_FEED_ADDRESS,
+        )
+        self._service_registry = {"technician": TECHNICIAN_ADDR}
+
+    def handle(self, cmd: Command) -> Reply:
+        logging.info("Mission Lead handling %s", cmd.action)
+        if cmd.action == "noop":
+            return Reply(
+                src=self.name,
+                dst=cmd.src,
+                status="ok",
+                payload={"message": "noop acknowledged"},
+                correlation_id=cmd.correlation_id,
+            )
+
+        if cmd.action == "echo":
+            return Reply(
+                src=self.name,
+                dst=cmd.src,
+                status="ok",
+                payload={"echo": cmd.payload},
+                correlation_id=cmd.correlation_id,
+            )
+
+        if cmd.action == "delegate":
+            return self._handle_delegate(cmd)
+
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="error",
+            payload={"error": f"unknown action: {cmd.action}"},
+            correlation_id=cmd.correlation_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Delegate handling
+    # ------------------------------------------------------------------
+    def _handle_delegate(self, cmd: Command) -> Reply:
+        target = cmd.payload.get("target")
+        action = cmd.payload.get("action", "noop")
+        payload = cmd.payload.get("payload", {})
+
+        if not isinstance(target, str):
+            return self._error_reply(cmd, "delegate requires target")
+        if not isinstance(payload, dict):
+            return self._error_reply(cmd, "delegate payload must be an object")
+
+        address = self._service_registry.get(target)
+        if not address:
+            return self._error_reply(cmd, f"unknown target: {target}")
+
+        child_cmd = Command(
+            src=self.name,
+            dst=target,
+            action=action,
+            payload=payload,
+        )
+
+        socket = make_req(zmq.Context.instance(), address)
+        try:
+            socket.send_string(child_cmd.to_json())
+            raw = socket.recv_string()
+        finally:
+            socket.close(linger=0)
+
+        child_reply = Reply.from_json(raw)
+        self.emit_event(
+            topic=f"delegate.{target}",
+            payload={
+                "command": child_cmd.to_dict(),
+                "reply": child_reply.to_dict(),
+            },
+        )
+
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status=child_reply.status,
+            payload={"delegate": child_reply.to_dict()},
+            correlation_id=cmd.correlation_id,
+        )
+
+    def _error_reply(self, cmd: Command, message: str) -> Reply:
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="error",
+            payload={"error": message},
+            correlation_id=cmd.correlation_id,
+        )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
+    service = MissionLeadService()
+    service.run()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/services/technician/__init__.py
+++ b/src/services/technician/__init__.py
@@ -1,0 +1,2 @@
+"""Spacecraft technician service."""
+

--- a/src/services/technician/main.py
+++ b/src/services/technician/main.py
@@ -1,0 +1,55 @@
+"""Technician agent implemented on top of BaseService."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from core.contracts import Command, Reply
+from services._common import BaseService
+
+SERVICE_NAME = "technician"
+COMMAND_ADDRESS = os.getenv("TECHNICIAN_COMMAND_ADDR", "tcp://*:5002")
+EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
+
+
+class TechnicianService(BaseService):
+    def __init__(self) -> None:
+        super().__init__(
+            name=SERVICE_NAME,
+            command_address=COMMAND_ADDRESS,
+            event_feed_address=EVENT_FEED_ADDRESS,
+        )
+        self._started_at = time.time()
+
+    def handle(self, cmd: Command) -> Reply:
+        if cmd.action == "noop":
+            return Reply(
+                src=self.name,
+                dst=cmd.src,
+                status="ok",
+                payload={"message": "technician standing by"},
+                correlation_id=cmd.correlation_id,
+            )
+
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="error",
+            payload={"error": f"unknown action: {cmd.action}"},
+            correlation_id=cmd.correlation_id,
+        )
+
+    def health_details(self) -> dict[str, float]:
+        return {"uptime": time.time() - self._started_at}
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
+    TechnicianService().run()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib
+import os
+import socket
+import sqlite3
+import time
+from multiprocessing import Process
+from typing import Dict
+
+import pytest
+
+zmq = pytest.importorskip("zmq")
+
+from core.contracts import Command, Reply
+from core.ipc import make_req
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.mark.timeout(30)
+def test_pipeline(tmp_path) -> None:
+    event_port = _get_free_port()
+    mission_lead_port = _get_free_port()
+    technician_port = _get_free_port()
+
+    db_path = tmp_path / "aerum.db"
+
+    env_updates: Dict[str, str] = {
+        "AERUM_DB_PATH": str(db_path),
+        "AERUM_EVENT_FEED": f"tcp://127.0.0.1:{event_port}",
+        "MISSION_LEAD_COMMAND_ADDR": f"tcp://127.0.0.1:{mission_lead_port}",
+        "MISSION_LEAD_CLIENT_ADDR": f"tcp://127.0.0.1:{mission_lead_port}",
+        "TECHNICIAN_COMMAND_ADDR": f"tcp://127.0.0.1:{technician_port}",
+    }
+
+    original_env = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+
+    processes: list[Process] = []
+
+    try:
+        datastore_module = importlib.reload(importlib.import_module("services.datastore.main"))
+        mission_lead_module = importlib.reload(importlib.import_module("services.mission_lead.main"))
+        technician_module = importlib.reload(importlib.import_module("services.technician.main"))
+
+        def start(target, name: str) -> None:
+            proc = Process(target=target, name=name)
+            proc.start()
+            processes.append(proc)
+
+        start(datastore_module.main, "datastore")
+        time.sleep(0.5)
+        start(mission_lead_module.main, "mission_lead")
+        start(technician_module.main, "technician")
+
+        time.sleep(1.0)
+
+        ctx = zmq.Context.instance()
+        socket = make_req(ctx, env_updates["MISSION_LEAD_CLIENT_ADDR"])
+        reply: Reply | None = None
+        try:
+            command = Command(
+                src="test_harness",
+                dst="mission_lead",
+                action="delegate",
+                payload={"target": "technician", "action": "noop", "payload": {}},
+            )
+            socket.send_string(command.to_json())
+            reply = Reply.from_json(socket.recv_string())
+        finally:
+            socket.close(linger=0)
+
+        assert reply is not None
+        assert reply.status == "ok"
+        delegated = reply.payload.get("delegate")
+        assert delegated["src"] == "technician"
+        assert delegated["status"] == "ok"
+
+        time.sleep(1.5)
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            events = conn.execute("SELECT src, topic, payload FROM events").fetchall()
+            health = conn.execute("SELECT src, status, details FROM health").fetchall()
+
+        event_sources = {row["src"] for row in events}
+        assert {"mission_lead", "technician"}.issubset(event_sources)
+
+        health_sources = {row["src"] for row in health}
+        assert {"mission_lead", "technician"}.issubset(health_sources)
+
+    finally:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in processes:
+            proc.join(timeout=2)
+
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+


### PR DESCRIPTION
## Summary
- add shared messaging contracts and ZeroMQ socket helpers for inter-service communication
- implement datastore, mission lead, and technician services publishing events and health via the shared BaseService template
- update the main entrypoint to launch the service stack and add an end-to-end pipeline test that verifies command delegation and telemetry persistence

## Testing
- pytest tests/e2e/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d9e25c21b4832496ffdd7b3daed4aa