### PR TITLE
Add HAL integration, FDIR service, and docker orchestration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["python", "-m", "src.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+version: "3.9"
+
+services:
+  datastore:
+    build: .
+    command: python -m src.services.datastore.main
+    environment:
+      AERUM_DB_PATH: /app/aerum.db
+      AERUM_EVENT_FEED: tcp://0.0.0.0:7000
+    volumes:
+      - .:/app
+    working_dir: /app
+    networks:
+      - aerum
+
+  mission_lead:
+    build: .
+    depends_on:
+      - datastore
+    command: python -m src.services.mission_lead.main
+    environment:
+      AERUM_EVENT_FEED: tcp://datastore:7000
+      MISSION_LEAD_COMMAND_ADDR: tcp://0.0.0.0:5001
+      MISSION_LEAD_CLIENT_ADDR: tcp://mission_lead:5001
+      TECHNICIAN_CLIENT_ADDR: tcp://technician:5002
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "5001:5001"
+    networks:
+      - aerum
+
+  technician:
+    build: .
+    depends_on:
+      - datastore
+    command: python -m src.services.technician.main
+    environment:
+      AERUM_EVENT_FEED: tcp://datastore:7000
+      TECHNICIAN_COMMAND_ADDR: tcp://0.0.0.0:5002
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "5002:5002"
+    networks:
+      - aerum
+
+  fault_analyst:
+    build: .
+    depends_on:
+      - datastore
+      - mission_lead
+      - technician
+    command: python -m src.services.fault_analyst.main
+    environment:
+      AERUM_EVENT_FEED: tcp://datastore:7000
+      FAULT_ANALYST_COMMAND_ADDR: tcp://0.0.0.0:5003
+      MISSION_LEAD_CLIENT_ADDR: tcp://mission_lead:5001
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "5003:5003"
+    networks:
+      - aerum
+
+networks:
+  aerum:
+    driver: bridge

--- a/src/core/hal/adapters/power_mock.py
+++ b/src/core/hal/adapters/power_mock.py
@@ -1,0 +1,18 @@
+"""Mock power subsystem adapter."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict
+
+from core.hal.base import Power
+
+
+class PowerMock(Power):
+    """Produce synthetic battery telemetry and switch acknowledgements."""
+
+    def read_battery(self) -> Dict[str, Any]:
+        return {"state_of_charge": random.uniform(70.0, 100.0)}
+
+    def switch(self, mode: str) -> Dict[str, Any]:
+        return {"mode": mode, "ok": True}

--- a/src/core/hal/adapters/propulsion_mock.py
+++ b/src/core/hal/adapters/propulsion_mock.py
@@ -1,0 +1,41 @@
+"""Mock propulsion adapter implementing the HAL interface."""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, Dict
+
+from core.hal.base import Propulsion
+
+
+class PropulsionMock(Propulsion):
+    """Simple propulsion mock producing pseudo telemetry."""
+
+    def __init__(self) -> None:
+        self._armed = False
+        self._last_telemetry: Dict[str, Any] = {"prop_pressure": 50.0, "temperature": 295.0}
+
+    def arm(self) -> Dict[str, Any]:
+        self._armed = True
+        return {"armed": True}
+
+    def fire(self, duration_s: float, valve_id: str) -> Dict[str, Any]:
+        logging.info("Mock propulsion firing valve %s for %.2fs", valve_id, duration_s)
+        pressure = random.uniform(10.0, 60.0)
+        telemetry = {"prop_pressure": pressure, "valve_id": valve_id, "duration_s": duration_s}
+        self._last_telemetry.update(telemetry)
+        return telemetry
+
+    def disarm(self) -> Dict[str, Any]:
+        self._armed = False
+        return {"armed": False}
+
+    def read_sensors(self) -> Dict[str, Any]:
+        snapshot = {
+            "prop_pressure": random.uniform(20.0, 65.0) if self._armed else self._last_telemetry.get("prop_pressure", 15.0),
+            "temperature": random.uniform(280.0, 320.0),
+            "armed": self._armed,
+        }
+        self._last_telemetry.update(snapshot)
+        return snapshot

--- a/src/core/hal/base.py
+++ b/src/core/hal/base.py
@@ -1,0 +1,38 @@
+"""Abstract base classes for Hardware Abstraction Layer components."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping
+
+
+class Propulsion(ABC):
+    """Abstraction for propulsion hardware control."""
+
+    @abstractmethod
+    def arm(self) -> Mapping[str, Any]:
+        """Arm the propulsion system and return status details."""
+
+    @abstractmethod
+    def fire(self, duration_s: float, valve_id: str) -> Mapping[str, Any]:
+        """Fire a thruster for ``duration_s`` seconds on the given valve."""
+
+    @abstractmethod
+    def disarm(self) -> Mapping[str, Any]:
+        """Disarm the propulsion system."""
+
+    @abstractmethod
+    def read_sensors(self) -> Mapping[str, Any]:
+        """Return the latest propulsion telemetry readings."""
+
+
+class Power(ABC):
+    """Abstraction for power subsystem interactions."""
+
+    @abstractmethod
+    def read_battery(self) -> Mapping[str, Any]:
+        """Return current battery telemetry information."""
+
+    @abstractmethod
+    def switch(self, mode: str) -> Mapping[str, Any]:
+        """Switch the power subsystem into the requested ``mode``."""

--- a/src/services/fault_analyst/main.py
+++ b/src/services/fault_analyst/main.py
@@ -1,0 +1,171 @@
+"""Fault Analyst (FDIR) service monitoring telemetry and health."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+import zmq
+
+from core.contracts import Command, Event, Health, Reply
+from core.ipc import TOPIC_EVENTS, TOPIC_HEALTH, make_req, make_sub
+from services._common import BaseService
+
+SERVICE_NAME = "fault_analyst"
+COMMAND_ADDRESS = os.getenv("FAULT_ANALYST_COMMAND_ADDR", "tcp://*:5003")
+EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
+MISSION_LEAD_CLIENT_ADDR = os.getenv("MISSION_LEAD_CLIENT_ADDR", "tcp://127.0.0.1:5001")
+
+
+class FaultAnalystService(BaseService):
+    """Service applying simple FDIR rules to telemetry streams."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=SERVICE_NAME,
+            command_address=COMMAND_ADDRESS,
+            event_feed_address=EVENT_FEED_ADDRESS,
+        )
+        self._ctx = zmq.Context.instance()
+        self._sub = make_sub(
+            self._ctx,
+            self.event_feed_address,
+            topics=[TOPIC_EVENTS, TOPIC_HEALTH],
+            bind=False,
+        )
+        self._monitor_stop = threading.Event()
+        self._monitor_thread = threading.Thread(
+            target=self._monitor_streams,
+            name="fault-analyst-monitor",
+            daemon=True,
+        )
+        self._mission_lead_addr = MISSION_LEAD_CLIENT_ADDR
+
+    def run(self) -> None:  # pragma: no cover - delegates to BaseService
+        if not self._monitor_thread.is_alive():
+            self._monitor_thread.start()
+        super().run()
+
+    def stop(self) -> None:
+        self._monitor_stop.set()
+        try:
+            self._sub.close(linger=0)
+        except zmq.error.ZMQError:  # pragma: no cover - defensive cleanup
+            pass
+        if self._monitor_thread.is_alive():
+            self._monitor_thread.join(timeout=1)
+        super().stop()
+
+    def handle(self, cmd: Command) -> Reply:
+        logging.info("Fault Analyst handling %s", cmd.action)
+        if cmd.action == "noop":
+            return Reply(
+                src=self.name,
+                dst=cmd.src,
+                status="ok",
+                payload={"message": "FDIR active"},
+                correlation_id=cmd.correlation_id,
+            )
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="error",
+            payload={"error": f"unknown action: {cmd.action}"},
+            correlation_id=cmd.correlation_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Monitoring helpers
+    # ------------------------------------------------------------------
+    def _monitor_streams(self) -> None:
+        poller = zmq.Poller()
+        poller.register(self._sub, zmq.POLLIN)
+        while not self._monitor_stop.is_set():
+            if not self._running.wait(timeout=0.1):
+                continue
+            try:
+                events = dict(poller.poll(timeout=200))
+            except zmq.error.ZMQError:
+                if self._monitor_stop.is_set():
+                    break
+                raise
+            if self._sub not in events:
+                continue
+            try:
+                message = self._sub.recv_string(flags=zmq.NOBLOCK)
+            except zmq.Again:
+                continue
+            except zmq.error.ZMQError:
+                if self._monitor_stop.is_set():
+                    break
+                raise
+            self._process_stream_message(message)
+
+    def _process_stream_message(self, message: str) -> None:
+        try:
+            topic, payload = message.split(" ", 1)
+        except ValueError:
+            logging.warning("Fault Analyst received malformed message: %s", message)
+            return
+
+        if topic == TOPIC_EVENTS:
+            event = Event.from_json(payload)
+            self._evaluate_event(event)
+        elif topic == TOPIC_HEALTH:
+            health = Health.from_json(payload)
+            self._evaluate_health(health)
+
+    def _evaluate_event(self, event: Event) -> None:
+        payload = event.payload
+        if not isinstance(payload, dict):
+            return
+        pressure = payload.get("prop_pressure")
+        if isinstance(pressure, (int, float)) and pressure < 20.0:
+            self._raise_alarm({"code": "PROP_PRESSURE_LOW", "pressure": pressure})
+
+    def _evaluate_health(self, health: Health) -> None:
+        if health.status == "FAILED":
+            self._raise_alarm({"code": "AGENT_FAILED", "agent": health.src})
+
+    def _raise_alarm(self, details: dict[str, Any]) -> None:
+        self.emit_event(topic="fdir.alarm", payload=details, level="ALARM")
+        self._suggest_safe_mode(details)
+
+    def _suggest_safe_mode(self, details: dict[str, Any]) -> None:
+        if not self._mission_lead_addr:
+            return
+        socket = make_req(self._ctx, self._mission_lead_addr)
+        socket.setsockopt(zmq.RCVTIMEO, 1000)
+        socket.setsockopt(zmq.SNDTIMEO, 1000)
+        command = Command(
+            src=self.name,
+            dst="mission_lead",
+            action="delegate",
+            payload={
+                "target": "mission_lead",
+                "action": "safe_mode",
+                "payload": details,
+            },
+        )
+        try:
+            socket.send_string(command.to_json())
+            # Best-effort receive; timeout will raise ZMQError which is ignored.
+            try:
+                socket.recv_string()
+            except zmq.error.ZMQError:
+                logging.info("Mission Lead did not respond to safe_mode suggestion")
+        except zmq.error.ZMQError:
+            logging.exception("Failed to send safe_mode suggestion to Mission Lead")
+        finally:
+            socket.close(linger=0)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
+    FaultAnalystService().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/mission_lead/main.py
+++ b/src/services/mission_lead/main.py
@@ -15,6 +15,7 @@ SERVICE_NAME = "mission_lead"
 COMMAND_ADDRESS = os.getenv("MISSION_LEAD_COMMAND_ADDR", "tcp://*:5001")
 EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
 TECHNICIAN_ADDR = os.getenv("TECHNICIAN_COMMAND_ADDR", "tcp://127.0.0.1:5002")
+TECHNICIAN_CLIENT_ADDR = os.getenv("TECHNICIAN_CLIENT_ADDR", TECHNICIAN_ADDR)
 
 
 class MissionLeadService(BaseService):
@@ -24,7 +25,7 @@ class MissionLeadService(BaseService):
             command_address=COMMAND_ADDRESS,
             event_feed_address=EVENT_FEED_ADDRESS,
         )
-        self._service_registry = {"technician": TECHNICIAN_ADDR}
+        self._service_registry = {"technician": TECHNICIAN_CLIENT_ADDR}
 
     def handle(self, cmd: Command) -> Reply:
         logging.info("Mission Lead handling %s", cmd.action)

--- a/src/services/technician/main.py
+++ b/src/services/technician/main.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import logging
 import os
 import time
+from typing import Any, Dict
 
 from core.contracts import Command, Reply
+from core.hal.adapters.propulsion_mock import PropulsionMock
+from core.hal.base import Propulsion
 from services._common import BaseService
 
 SERVICE_NAME = "technician"
@@ -15,13 +18,14 @@ EVENT_FEED_ADDRESS = os.getenv("AERUM_EVENT_FEED", "tcp://127.0.0.1:7000")
 
 
 class TechnicianService(BaseService):
-    def __init__(self) -> None:
+    def __init__(self, propulsion: Propulsion | None = None) -> None:
         super().__init__(
             name=SERVICE_NAME,
             command_address=COMMAND_ADDRESS,
             event_feed_address=EVENT_FEED_ADDRESS,
         )
         self._started_at = time.time()
+        self._propulsion = propulsion or PropulsionMock()
 
     def handle(self, cmd: Command) -> Reply:
         if cmd.action == "noop":
@@ -33,6 +37,18 @@ class TechnicianService(BaseService):
                 correlation_id=cmd.correlation_id,
             )
 
+        if cmd.action == "arm_propulsion":
+            return self._handle_arm(cmd)
+
+        if cmd.action == "fire_thruster":
+            return self._handle_fire(cmd)
+
+        if cmd.action == "disarm_propulsion":
+            return self._handle_disarm(cmd)
+
+        if cmd.action == "read_propulsion":
+            return self._handle_read(cmd)
+
         return Reply(
             src=self.name,
             dst=cmd.src,
@@ -43,6 +59,58 @@ class TechnicianService(BaseService):
 
     def health_details(self) -> dict[str, float]:
         return {"uptime": time.time() - self._started_at}
+
+    # ------------------------------------------------------------------
+    # Command handlers
+    # ------------------------------------------------------------------
+    def _handle_arm(self, cmd: Command) -> Reply:
+        result = self._propulsion.arm()
+        return self._ok_reply(cmd, {"arm": result})
+
+    def _handle_fire(self, cmd: Command) -> Reply:
+        payload = cmd.payload or {}
+        duration = payload.get("duration_s")
+        valve_id = payload.get("valve_id")
+
+        if not isinstance(duration, (int, float)) or not isinstance(valve_id, str):
+            return self._error_reply(cmd, "fire_thruster requires duration_s (number) and valve_id (string)")
+
+        telemetry = self._propulsion.fire(float(duration), valve_id)
+        self._publish_telemetry(telemetry)
+        return self._ok_reply(cmd, {"telemetry": telemetry})
+
+    def _handle_disarm(self, cmd: Command) -> Reply:
+        result = self._propulsion.disarm()
+        return self._ok_reply(cmd, {"disarm": result})
+
+    def _handle_read(self, cmd: Command) -> Reply:
+        telemetry = self._propulsion.read_sensors()
+        self._publish_telemetry(telemetry)
+        return self._ok_reply(cmd, {"telemetry": telemetry})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _publish_telemetry(self, telemetry: Dict[str, Any]) -> None:
+        self.emit_event(topic="telemetry.propulsion", payload=dict(telemetry))
+
+    def _ok_reply(self, cmd: Command, payload: Dict[str, Any]) -> Reply:
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="ok",
+            payload=payload,
+            correlation_id=cmd.correlation_id,
+        )
+
+    def _error_reply(self, cmd: Command, message: str) -> Reply:
+        return Reply(
+            src=self.name,
+            dst=cmd.src,
+            status="error",
+            payload={"error": message},
+            correlation_id=cmd.correlation_id,
+        )
 
 
 def main() -> None:

--- a/tests/e2e/test_fault_and_hal.py
+++ b/tests/e2e/test_fault_and_hal.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import socket
+import sqlite3
+import time
+from multiprocessing import Process
+from typing import Dict, List
+
+import pytest
+
+zmq = pytest.importorskip("zmq")
+
+from core.contracts import Command, Reply
+from core.ipc import make_req
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_test_technician() -> None:
+    from services.technician.main import TechnicianService
+    from core.hal.adapters.propulsion_mock import PropulsionMock
+
+    class DeterministicPropulsion(PropulsionMock):
+        def __init__(self) -> None:
+            super().__init__()
+            self._pressures: List[float] = [45.0, 15.0]
+
+        def fire(self, duration_s: float, valve_id: str) -> Dict[str, float | str]:
+            if self._pressures:
+                pressure = self._pressures.pop(0)
+            else:
+                pressure = 15.0
+            telemetry: Dict[str, float | str] = {
+                "prop_pressure": pressure,
+                "valve_id": valve_id,
+                "duration_s": duration_s,
+            }
+            self._last_telemetry.update(telemetry)
+            return telemetry
+
+    TechnicianService(propulsion=DeterministicPropulsion()).run()
+
+
+@pytest.mark.timeout(45)
+def test_fault_detection_and_hal(tmp_path) -> None:
+    event_port = _get_free_port()
+    mission_lead_port = _get_free_port()
+    technician_port = _get_free_port()
+    fault_port = _get_free_port()
+
+    db_path = tmp_path / "aerum_fault.db"
+
+    env_updates = {
+        "AERUM_DB_PATH": str(db_path),
+        "AERUM_EVENT_FEED": f"tcp://127.0.0.1:{event_port}",
+        "MISSION_LEAD_COMMAND_ADDR": f"tcp://127.0.0.1:{mission_lead_port}",
+        "MISSION_LEAD_CLIENT_ADDR": f"tcp://127.0.0.1:{mission_lead_port}",
+        "TECHNICIAN_COMMAND_ADDR": f"tcp://127.0.0.1:{technician_port}",
+        "FAULT_ANALYST_COMMAND_ADDR": f"tcp://127.0.0.1:{fault_port}",
+    }
+
+    original_env = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+
+    processes: list[Process] = []
+
+    try:
+        datastore_module = importlib.reload(importlib.import_module("services.datastore.main"))
+        mission_lead_module = importlib.reload(importlib.import_module("services.mission_lead.main"))
+        fault_module = importlib.reload(importlib.import_module("services.fault_analyst.main"))
+
+        def start(target, name: str) -> None:
+            proc = Process(target=target, name=name)
+            proc.start()
+            processes.append(proc)
+
+        start(datastore_module.main, "datastore")
+        time.sleep(0.5)
+        start(mission_lead_module.main, "mission_lead")
+        start(_run_test_technician, "technician")
+        start(fault_module.main, "fault_analyst")
+
+        time.sleep(1.0)
+
+        ctx = zmq.Context.instance()
+        socket = make_req(ctx, env_updates["MISSION_LEAD_CLIENT_ADDR"])
+        try:
+            arm_command = Command(
+                src="test_harness",
+                dst="mission_lead",
+                action="delegate",
+                payload={"target": "technician", "action": "arm_propulsion", "payload": {}},
+            )
+            socket.send_string(arm_command.to_json())
+            arm_reply = Reply.from_json(socket.recv_string())
+            assert arm_reply.status == "ok"
+
+            fire_command = Command(
+                src="test_harness",
+                dst="mission_lead",
+                action="delegate",
+                payload={
+                    "target": "technician",
+                    "action": "fire_thruster",
+                    "payload": {"duration_s": 1.0, "valve_id": "A"},
+                },
+            )
+            socket.send_string(fire_command.to_json())
+            fire_reply = Reply.from_json(socket.recv_string())
+
+            fire_low_command = Command(
+                src="test_harness",
+                dst="mission_lead",
+                action="delegate",
+                payload={
+                    "target": "technician",
+                    "action": "fire_thruster",
+                    "payload": {"duration_s": 0.5, "valve_id": "B"},
+                },
+            )
+            socket.send_string(fire_low_command.to_json())
+            fire_low_reply = Reply.from_json(socket.recv_string())
+        finally:
+            socket.close(linger=0)
+
+        assert fire_reply.status == "ok"
+        assert fire_low_reply.status == "ok"
+        assert "telemetry" in fire_reply.payload.get("delegate", {})
+        low_pressure = (
+            fire_low_reply.payload.get("delegate", {})
+            .get("payload", {})
+            .get("telemetry", {})
+            .get("prop_pressure")
+        )
+        assert isinstance(low_pressure, (int, float)) and low_pressure < 20.0
+
+        time.sleep(2.0)
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            telemetry_rows = conn.execute(
+                "SELECT payload FROM events WHERE topic = ?", ("telemetry.propulsion",)
+            ).fetchall()
+            alarm_rows = conn.execute(
+                "SELECT payload, level FROM events WHERE topic = ?", ("fdir.alarm",)
+            ).fetchall()
+
+        assert telemetry_rows, "Expected propulsion telemetry events"
+        telemetry_payloads = [json.loads(row["payload"]) for row in telemetry_rows]
+        assert any(
+            payload["payload"].get("prop_pressure") is not None for payload in telemetry_payloads
+        )
+
+        assert alarm_rows, "Expected FDIR alarm events"
+        alarm_payloads = [json.loads(row["payload"]) for row in alarm_rows]
+        assert any(
+            alarm["payload"].get("code") == "PROP_PRESSURE_LOW" and alarm["level"] == "ALARM"
+            for alarm in alarm_payloads
+        )
+
+    finally:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in processes:
+            proc.join(timeout=2)
+
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value


### PR DESCRIPTION
## Summary
- add a dedicated fault analyst service that subscribes to event and health streams and raises propulsion/agent alarms
- introduce HAL base interfaces with mock propulsion and power adapters and wire the technician to emit propulsion telemetry
- add an end-to-end regression test plus Docker assets (Dockerfile, docker-compose) and mission lead address config for container orchestration

## Testing
- pytest tests/e2e/test_fault_and_hal.py *(skipped: pyzmq not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e69b03ac83249771c2c3b9f0574e