### PR TITLE
Launch dashboard service from main entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,21 @@ services:
     networks:
       - aerum
 
+  dashboard:
+    build: .
+    depends_on:
+      - datastore
+    command: python -m src.services.dashboard.app
+    environment:
+      AERUM_DB_PATH: /app/aerum.db
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "5000:5000"
+    networks:
+      - aerum
+
 networks:
   aerum:
     driver: bridge

--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import subprocess
+import sys
 import time
 from multiprocessing import Process
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import zmq
 
@@ -48,6 +50,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
 
     processes: List[Process] = []
+    dashboard_proc: Optional[subprocess.Popen[str]] = None
 
     def shutdown(_signum: int, _frame) -> None:
         logging.info("Shutting down service stack")
@@ -56,6 +59,12 @@ def main() -> None:
                 proc.terminate()
         for proc in processes:
             proc.join(timeout=2)
+        if dashboard_proc and dashboard_proc.poll() is None:
+            dashboard_proc.terminate()
+            try:
+                dashboard_proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                dashboard_proc.kill()
         raise SystemExit(0)
 
     signal.signal(signal.SIGINT, shutdown)
@@ -66,6 +75,17 @@ def main() -> None:
     time.sleep(0.5)
     processes.append(_start_process(mission_lead_main, "mission_lead"))
     processes.append(_start_process(technician_main, "technician"))
+
+    if os.getenv("AERUM_NO_DASHBOARD"):
+        logging.info("Dashboard service launch skipped (AERUM_NO_DASHBOARD set)")
+    else:
+        dashboard_cmd = [sys.executable, "-m", "src.services.dashboard.app"]
+        try:
+            dashboard_proc = subprocess.Popen(dashboard_cmd)
+        except OSError as exc:
+            logging.error("Failed to launch dashboard service: %s", exc)
+        else:
+            logging.info("Dashboard service running at http://localhost:5000")
 
     time.sleep(1.0)
     try:

--- a/src/services/dashboard/app.py
+++ b/src/services/dashboard/app.py
@@ -1,0 +1,175 @@
+"""Dashboard service providing REST APIs and SSE for mission data."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Generator, List
+
+from flask import Flask, Response, jsonify, send_from_directory
+
+DB_PATH = os.getenv("AERUM_DB_PATH", "aerum.db")
+POLL_INTERVAL = float(os.getenv("AERUM_DASHBOARD_POLL", "1.0"))
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+
+
+def _connect(db_path: str = DB_PATH) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _parse_json_field(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return {"raw": value}
+
+
+def _row_to_event(row: sqlite3.Row) -> Dict:
+    payload = row["payload"] if "payload" in row.keys() else row[4]
+    data = {
+        "rowid": row["rowid"],
+        "timestamp": row["t"],
+        "source": row["src"],
+        "level": row["level"],
+        "topic": row["topic"],
+        "payload": _parse_json_field(payload),
+    }
+    return data
+
+
+def _row_to_health(row: sqlite3.Row) -> Dict:
+    details = row["details"] if "details" in row.keys() else row[3]
+    return {
+        "timestamp": row["t"],
+        "agent": row["src"],
+        "status": row["status"],
+        "details": _parse_json_field(details),
+    }
+
+
+class EventStreamer:
+    """Background poller that broadcasts new events to SSE subscribers."""
+
+    def __init__(self, db_path: str = DB_PATH, poll_interval: float = POLL_INTERVAL):
+        self._db_path = db_path
+        self._poll_interval = poll_interval
+        self._subscribers: List[queue.Queue] = []
+        self._lock = threading.Lock()
+        self._last_rowid = self._get_last_rowid()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _get_last_rowid(self) -> int:
+        with _connect(self._db_path) as conn:
+            row = conn.execute("SELECT IFNULL(MAX(rowid), 0) AS last_id FROM events").fetchone()
+            return int(row["last_id"] or 0)
+
+    def subscribe(self) -> queue.Queue:
+        q: queue.Queue = queue.Queue(maxsize=100)
+        with self._lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: queue.Queue) -> None:
+        with self._lock:
+            if q in self._subscribers:
+                self._subscribers.remove(q)
+
+    def _publish(self, event: Dict) -> None:
+        with self._lock:
+            for subscriber in list(self._subscribers):
+                try:
+                    subscriber.put_nowait(event)
+                except queue.Full:  # pragma: no cover - defensive
+                    # Drop the subscriber if it can't keep up.
+                    self._subscribers.remove(subscriber)
+
+    def _poll(self, conn: sqlite3.Connection) -> None:
+        rows = conn.execute(
+            "SELECT rowid, t, src, level, topic, payload FROM events WHERE rowid > ? ORDER BY rowid ASC",
+            (self._last_rowid,),
+        ).fetchall()
+        for row in rows:
+            event = _row_to_event(row)
+            self._last_rowid = max(self._last_rowid, event["rowid"])
+            self._publish(event)
+
+    def _run(self) -> None:
+        conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        try:
+            while True:
+                self._poll(conn)
+                time.sleep(self._poll_interval)
+        finally:  # pragma: no cover - best effort cleanup
+            conn.close()
+
+
+app = Flask(__name__)
+streamer = EventStreamer()
+
+
+@app.route("/")
+def dashboard() -> Response:
+    return send_from_directory(str(STATIC_DIR), "dashboard.html")
+
+
+@app.route("/events")
+def get_events() -> Response:
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT rowid, t, src, level, topic, payload FROM events ORDER BY rowid DESC LIMIT 50"
+        ).fetchall()
+        events = [_row_to_event(row) for row in rows]
+    return jsonify(list(reversed(events)))
+
+
+@app.route("/health")
+def get_health() -> Response:
+    with _connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT h.rowid, h.t, h.src, h.status, h.details
+            FROM health h
+            INNER JOIN (
+                SELECT src, MAX(t) AS latest
+                FROM health
+                GROUP BY src
+            ) latest_health ON latest_health.src = h.src AND latest_health.latest = h.t
+            ORDER BY h.t DESC
+            """
+        ).fetchall()
+        health = [_row_to_health(row) for row in rows]
+    return jsonify(health)
+
+
+@app.route("/missions")
+def get_missions() -> Response:
+    return jsonify([{"id": "demo", "status": "idle"}])
+
+
+@app.route("/stream")
+def stream_events() -> Response:
+    def event_stream() -> Generator[str, None, None]:
+        subscriber = streamer.subscribe()
+        try:
+            while True:
+                event = subscriber.get()
+                yield f"data: {json.dumps(event)}\n\n"
+        except GeneratorExit:  # pragma: no cover - triggered on disconnect
+            streamer.unsubscribe(subscriber)
+
+    return Response(event_stream(), mimetype="text/event-stream")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/src/services/dashboard/static/dashboard.html
+++ b/src/services/dashboard/static/dashboard.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AERUM Mission Control</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0f141b;
+        --panel: #1a2230;
+        --accent: #3ec5ff;
+        --text: #e0f0ff;
+        --muted: #7a8c9f;
+        --success: #27d17d;
+        --warn: #ffb347;
+        --danger: #ff5f6d;
+      }
+
+      * {
+        box-sizing: border-box;
+        font-family: "SF Mono", "Fira Code", "Roboto Mono", monospace;
+      }
+
+      body {
+        margin: 0;
+        background: radial-gradient(circle at top, rgba(62, 197, 255, 0.08), transparent 55%),
+          var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      header {
+        padding: 1.5rem 2rem;
+        background: linear-gradient(135deg, rgba(62, 197, 255, 0.2), transparent);
+        border-bottom: 1px solid rgba(62, 197, 255, 0.25);
+        display: flex;
+        align-items: baseline;
+        gap: 1rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 1.75rem;
+        letter-spacing: 0.2rem;
+        text-transform: uppercase;
+      }
+
+      header span {
+        font-size: 0.85rem;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+
+      main {
+        flex: 1;
+        padding: 2rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      section {
+        background: linear-gradient(160deg, rgba(62, 197, 255, 0.08), transparent 70%), var(--panel);
+        border: 1px solid rgba(62, 197, 255, 0.15);
+        border-radius: 12px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+
+      section h2 {
+        margin: 0 0 1rem 0;
+        font-size: 1rem;
+        letter-spacing: 0.15rem;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .events-list,
+      .health-list,
+      .missions-list {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        overflow-y: auto;
+        padding-right: 0.5rem;
+      }
+
+      .event {
+        border-left: 3px solid var(--accent);
+        padding-left: 0.75rem;
+      }
+
+      .event .meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.75rem;
+        color: var(--muted);
+        margin-bottom: 0.25rem;
+      }
+
+      .event .payload {
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.1rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        letter-spacing: 0.1rem;
+        text-transform: uppercase;
+        background: rgba(62, 197, 255, 0.15);
+      }
+
+      .level-info {
+        border-left-color: var(--accent);
+      }
+
+      .level-warning {
+        border-left-color: var(--warn);
+      }
+
+      .level-error,
+      .level-critical {
+        border-left-color: var(--danger);
+      }
+
+      .health {
+        display: grid;
+        grid-template-columns: auto auto;
+        gap: 0.25rem 1rem;
+        font-size: 0.85rem;
+      }
+
+      .health .status {
+        font-weight: 600;
+      }
+
+      .status-ok {
+        color: var(--success);
+      }
+
+      .status-degraded {
+        color: var(--warn);
+      }
+
+      .status-down {
+        color: var(--danger);
+      }
+
+      .missions-list .mission {
+        padding: 0.75rem;
+        background: rgba(62, 197, 255, 0.05);
+        border-radius: 8px;
+        border: 1px solid rgba(62, 197, 255, 0.1);
+      }
+
+      footer {
+        padding: 0.75rem 2rem;
+        background: rgba(10, 12, 18, 0.9);
+        font-size: 0.75rem;
+        color: var(--muted);
+        display: flex;
+        justify-content: space-between;
+      }
+
+      footer span {
+        text-transform: uppercase;
+        letter-spacing: 0.1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>AERUM</h1>
+      <span>Mission Control Dashboard</span>
+    </header>
+    <main>
+      <section>
+        <h2>Event Feed</h2>
+        <div class="events-list" id="events"></div>
+      </section>
+      <section>
+        <h2>Agent Health</h2>
+        <div class="health-list" id="health"></div>
+      </section>
+      <section>
+        <h2>Missions</h2>
+        <div class="missions-list" id="missions"></div>
+      </section>
+    </main>
+    <footer>
+      <span id="status">Connecting…</span>
+      <span id="timestamp"></span>
+    </footer>
+    <script>
+      const eventsContainer = document.getElementById("events");
+      const healthContainer = document.getElementById("health");
+      const missionsContainer = document.getElementById("missions");
+      const statusEl = document.getElementById("status");
+      const tsEl = document.getElementById("timestamp");
+
+      function formatTime(unixSeconds) {
+        if (!unixSeconds) return "";
+        const date = new Date(unixSeconds * 1000);
+        return date.toLocaleTimeString();
+      }
+
+      function renderEvent(event) {
+        const div = document.createElement("div");
+        div.className = `event level-${(event.level || "info").toLowerCase()}`;
+        const payload = typeof event.payload === "object" ? JSON.stringify(event.payload, null, 2) : String(event.payload);
+        div.innerHTML = `
+          <div class="meta">
+            <span>${formatTime(event.timestamp)} · <strong>${event.source || "unknown"}</strong></span>
+            <span class="badge">${event.topic || "event"}</span>
+          </div>
+          <div class="payload">${payload}</div>
+        `;
+        return div;
+      }
+
+      function renderHealth(health) {
+        const container = document.createElement("div");
+        container.className = "health";
+        const statusClass = `status-${(health.status || "ok").toLowerCase()}`;
+        const details = typeof health.details === "object" ? JSON.stringify(health.details) : String(health.details || "");
+        container.innerHTML = `
+          <div>${health.agent || "agent"}</div>
+          <div class="status ${statusClass}">${health.status || "OK"}</div>
+          <div style="grid-column: 1 / span 2; font-size: 0.75rem; color: var(--muted);">
+            Updated ${formatTime(health.timestamp)} · ${details}
+          </div>
+        `;
+        return container;
+      }
+
+      function renderMission(mission) {
+        const div = document.createElement("div");
+        div.className = "mission";
+        div.innerHTML = `
+          <div style="font-size: 0.9rem;">Mission <strong>${mission.id}</strong></div>
+          <div style="color: var(--muted); font-size: 0.75rem;">Status: ${mission.status}</div>
+        `;
+        return div;
+      }
+
+      function prependEvent(event) {
+        const element = renderEvent(event);
+        eventsContainer.prepend(element);
+        while (eventsContainer.children.length > 50) {
+          eventsContainer.removeChild(eventsContainer.lastChild);
+        }
+      }
+
+      async function loadInitialData() {
+        try {
+          const [eventsRes, healthRes, missionsRes] = await Promise.all([
+            fetch("/events"),
+            fetch("/health"),
+            fetch("/missions")
+          ]);
+          const events = await eventsRes.json();
+          const health = await healthRes.json();
+          const missions = await missionsRes.json();
+
+          eventsContainer.innerHTML = "";
+          events.reverse().forEach((event) => eventsContainer.appendChild(renderEvent(event)));
+
+          healthContainer.innerHTML = "";
+          health.forEach((row) => healthContainer.appendChild(renderHealth(row)));
+
+          missionsContainer.innerHTML = "";
+          missions.forEach((mission) => missionsContainer.appendChild(renderMission(mission)));
+
+          statusEl.textContent = "Live";
+          tsEl.textContent = `Last refresh ${new Date().toLocaleTimeString()}`;
+        } catch (error) {
+          statusEl.textContent = "Offline";
+          tsEl.textContent = "";
+        }
+      }
+
+      function startStream() {
+        const source = new EventSource("/stream");
+        source.onopen = () => {
+          statusEl.textContent = "Streaming";
+        };
+        source.onerror = () => {
+          statusEl.textContent = "Reconnecting";
+        };
+        source.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            prependEvent(data);
+            tsEl.textContent = `Updated ${new Date().toLocaleTimeString()}`;
+          } catch (err) {
+            console.error("Failed to parse SSE payload", err);
+          }
+        };
+      }
+
+      loadInitialData();
+      startStream();
+      setInterval(loadInitialData, 15000);
+    </script>
+  </body>
+</html>

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -1,0 +1,110 @@
+import importlib
+import json
+import os
+import sqlite3
+import sys
+import time
+from multiprocessing import Process
+from pathlib import Path
+from typing import Dict, List
+from urllib import request
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = PROJECT_ROOT / "src"
+
+for path in (PROJECT_ROOT, SRC_ROOT):
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.insert(0, str_path)
+
+pytest.importorskip("zmq")
+
+
+def test_dashboard_rest_endpoints(tmp_path) -> None:
+    db_path = tmp_path / "aerum.db"
+    dashboard_port = _get_free_port()
+
+    env_updates: Dict[str, str] = {
+        "AERUM_DB_PATH": str(db_path),
+    }
+
+    original_env = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+
+    processes: List[Process] = []
+
+    try:
+        datastore_module = importlib.reload(importlib.import_module("services.datastore.main"))
+        dashboard_module = importlib.reload(importlib.import_module("services.dashboard.app"))
+
+        datastore_module.init_db(str(db_path))
+
+        _start_process(datastore_module.main, processes, name="datastore")
+        time.sleep(0.5)
+        _start_process(
+            dashboard_module.app.run,
+            processes,
+            name="dashboard",
+            kwargs={"host": "127.0.0.1", "port": dashboard_port, "debug": False, "use_reloader": False},
+        )
+
+        _wait_for_http(f"http://127.0.0.1:{dashboard_port}/health")
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO events (t, src, level, topic, payload) VALUES (?, ?, ?, ?, ?)",
+                (time.time(), "test_harness", "INFO", "demo", json.dumps({"message": "hello"})),
+            )
+            conn.commit()
+
+        events = _fetch_json(f"http://127.0.0.1:{dashboard_port}/events")
+        assert any(event.get("source") == "test_harness" for event in events)
+
+        health = _fetch_json(f"http://127.0.0.1:{dashboard_port}/health")
+        assert isinstance(health, list)
+
+    finally:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in processes:
+            proc.join(timeout=2)
+
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _start_process(target, processes: List[Process], name: str, kwargs: Dict | None = None) -> None:
+    proc = Process(target=target, name=name, kwargs=kwargs or {})
+    proc.start()
+    processes.append(proc)
+
+
+def _wait_for_http(url: str, timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with request.urlopen(url, timeout=1):
+                return
+        except Exception:  # pragma: no cover - best effort wait
+            time.sleep(0.1)
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+def _fetch_json(url: str):
+    with request.urlopen(url, timeout=5) as response:
+        data = response.read().decode("utf-8")
+    return json.loads(data)
+
+
+def _get_free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]


### PR DESCRIPTION
## Summary
- launch the dashboard Flask service from `python main.py` via `subprocess.Popen`
- allow skipping the dashboard with `AERUM_NO_DASHBOARD` and tear it down during shutdown

## Testing
- pytest tests/e2e/test_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ea791dbc83248c13ebe2c586e187